### PR TITLE
Displaypad bugs (page switching)

### DIFF
--- a/devices/displaypad/panel.py
+++ b/devices/displaypad/panel.py
@@ -37,6 +37,17 @@ from shared.config import (
     _load_displaypad_page_timeouts, _save_displaypad_page_timeouts,
 )
 
+# Set BASECAMP_PAGE_DEBUG=1 in the environment to trace page-switch/upload
+# decisions (also toggles matching trace lines in shared/plugins.py and
+# page-bound widget plugins). Off by default.
+_PAGE_DEBUG = os.environ.get("BASECAMP_PAGE_DEBUG", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _dbg(msg):
+    if _PAGE_DEBUG:
+        print(msg, flush=True)
+
+
 try:
     import hid
     HID_AVAILABLE = True
@@ -2610,10 +2621,29 @@ class DisplayPadPanel(ctk.CTkFrame):
         if self._fullscreen_group:
             self._page_fullscreen.setdefault(old_page, None)  # keep existing path
 
+        _dbg(f"[DBG switch] {old_page} -> {page_num} | saved page_images[{old_page}]={self._page_images[old_page]}")
+
         self._current_page = page_num
+
+        # Start/stop page-bound service plugins using their normal start()/
+        # stop() lifecycle: a plugin whose button was on the page we're
+        # leaving gets stop()'d (it was otherwise still polling and painting
+        # over that key index on the new page, since keys are shared
+        # hardware slots across pages), and a plugin whose button is on the
+        # page we're entering gets start()'d right away.
+        pm = getattr(self._app, "_plugin_manager", None)
+        if pm:
+            try:
+                pm.sync_services_for_page(page_num)
+            except Exception as e:
+                print(f"[Plugin] sync_services_for_page failed: {e}")
+
+        _dbg(f"[DBG switch] after sync_services_for_page({page_num}): "
+              f"page_images[{page_num}]={self._page_images.get(page_num)}")
 
         # Load new page
         self._images = dict(self._page_images.get(page_num, {}))
+        _dbg(f"[DBG switch] loaded self._images for page {page_num} = {self._images}")
         self._gif_frames = {}
         self._gui_frames_sm = {}
         self._gui_fidx = {}
@@ -3184,6 +3214,7 @@ class DisplayPadPanel(ctk.CTkFrame):
     def _start_upload(self):
         assigned = {int(k): v for k, v in self._images.items()
                     if v and os.path.exists(v)}
+        _dbg(f"[DBG upload] page={self._current_page} uploading assigned={assigned}")
         # Include gif_frames keys not in _images (fullscreen GIF loaded without individual paths)
         for k in self._gif_frames:
             if k not in assigned:
@@ -3502,6 +3533,7 @@ class DisplayPadPanel(ctk.CTkFrame):
         """
         if not (0 <= key_index <= 11):
             return
+        _dbg(f"[DBG push_plugin_image] key={key_index} current_page={self._current_page}")
         img = pil_image.convert("RGB").resize((ICON_SIZE, ICON_SIZE), Image.LANCZOS)
         rot = self._rotation
         if rot:

--- a/devices/displaypad/panel.py
+++ b/devices/displaypad/panel.py
@@ -130,18 +130,7 @@ def _open_interfaces():
                 hid_dev.close()
                 raise RuntimeError("DisplayPad not found via PyUSB")
             usb.util.claim_interface(usb_dev, 1)
-            # Quiesce the display interface with SET_IDLE(0) before streaming
-            # image data. Windows Base Camp issues SET_IDLE for interfaces 0, 1
-            # and 3; the Linux stack only covered 0 and 3 (hidraw does them),
-            # leaving interface 1 un-idled. A pad that was unplugged/replugged
-            # could then wedge interface 1 and the first upload timed out
-            # (issue #40, from FransM's Windows-vs-Linux capture comparison).
-            # HID class request: bmRequestType=0x21, bRequest=SET_IDLE(0x0A),
-            # wValue=0 (duration 0, report 0), wIndex=interface 1. Best-effort.
-            try:
-                usb_dev.ctrl_transfer(0x21, 0x0A, 0x0000, 1, None, timeout=500)
-            except Exception:
-                pass
+            _init_handshake_ctrl(usb_dev)
             return usb_dev, hid_dev
         except Exception as e:
             last_err = e
@@ -152,6 +141,70 @@ def _open_interfaces():
                     pass
             time.sleep(0.2)
     raise last_err if last_err else RuntimeError("DisplayPad open failed")
+
+
+def _init_handshake_ctrl(usb_dev):
+    """
+    Step 1: temporarily claim IF0 (the keyboard interface). IF0 is only
+    needed for the two control transfers below, so detach its kernel driver
+    first and reattach it afterwards — the keyboard must keep working.
+
+    Step 2: SET_IDLE (bRequest 0x0A, wValue 0) on IF0, IF1 (pixels) and IF3
+    (cmd) to suppress repeated reports when nothing is changing. EPIPE /
+    any failure here just means the interface doesn't support it and is
+    ignored (best-effort, matching warnLibusb's non-fatal handling).
+
+    Step 3: SET_REPORT (output report 3, payload {0x03, 0x01}) on IF0 to
+    enable the device's event reporting mode (verified by USB capture on
+    Windows).
+
+    Step 4: release IF0 and reattach its kernel driver. IF1 stays claimed
+    by us (already claimed by the caller) for the rest of the session.
+    """
+    if0_was_active = False
+    try:
+        if0_was_active = bool(usb_dev.is_kernel_driver_active(0))
+    except Exception:
+        pass
+    if if0_was_active:
+        try:
+            usb_dev.detach_kernel_driver(0)
+        except Exception:
+            pass
+
+    if0_claimed = False
+    try:
+        usb.util.claim_interface(usb_dev, 0)
+        if0_claimed = True
+    except Exception:
+        pass
+
+    def _set_idle(iface):
+        try:
+            usb_dev.ctrl_transfer(0x21, 0x0A, 0x0000, iface, None, timeout=500)
+        except Exception:
+            pass
+
+    if if0_claimed:
+        _set_idle(0)
+    _set_idle(1)  # IF_PIXELS
+    _set_idle(3)  # IF_CMD
+
+    if if0_claimed:
+        try:
+            usb_dev.ctrl_transfer(0x21, 0x09, 0x0203, 0x0000,
+                                   bytes([0x03, 0x01]), timeout=500)
+        except Exception:
+            pass
+        try:
+            usb.util.release_interface(usb_dev, 0)
+        except Exception:
+            pass
+        if if0_was_active:
+            try:
+                usb_dev.attach_kernel_driver(0)
+            except Exception:
+                pass
 
 
 def _close_interfaces(usb_dev, hid_dev):
@@ -170,28 +223,47 @@ def _close_interfaces(usb_dev, hid_dev):
 
 
 def _init_device(hid_dev):
-    """Bring the DisplayPad up by sending INIT and waiting for its 0x11 reply.
+    """Bring the DisplayPad up: send INIT_MSG on IF3 and wait for a matching echo
 
-    After an unplug/replug the pad frequently misses the first INIT: the old
-    code wrote INIT once and then blocked reading for up to 10s before trying
-    again, so recovery was slow and often timed out with "Connection timed out"
-    when the GUI was restarted on a replugged pad (issue #40). Windows Base Camp
-    instead re-sends INIT several times until the pad answers. We do the same —
-    short read windows between frequent re-writes make a missed INIT recover in
-    a fraction of a second instead of stalling."""
-    for attempt in range(15):
-        hid_dev.write(INIT_MSG)
-        for _ in range(10):
-            resp = hid_dev.read(64, timeout=100)
-            if resp and resp[0] == 0x11:
-                # The pad acknowledges INIT before its display engine is ready to
-                # accept pixel data; streaming immediately after a fresh
-                # enumeration timed out the first image write ("Connection timed
-                # out", issue #43). A short settle lets the firmware come up.
-                time.sleep(0.25)
-                return
-        time.sleep(0.1)
-    raise RuntimeError("DisplayPad did not respond to INIT")
+    Send INIT_MSG, then wait up to 500 ms for a reply. The reply is accepted
+    once its first 5 bytes echo what we sent. Retry up to 60 times with a
+    10 ms gap after a failed write or read — the device can be slow to come
+    up after a fresh plug-in (issue #40)."""
+    # INIT_MSG here carries a leading HID report-ID byte (0x00) that
+    # hid_dev.write() needs; the device's raw 64-byte packet — and the echo
+    # it sends back via hid_dev.read() — does not include that byte, so the
+    # comparison is offset by one to line up with init.cpp's INIT_MSG[0:5]
+    # (0x11 0x80 0x00 0x00 0x01).
+    pkt = INIT_MSG
+    echo = pkt[1:6]
+    ack_received = False
+    for _attempt in range(60):
+        try:
+            hid_dev.write(pkt)
+        except Exception:
+            time.sleep(0.01)
+            continue
+
+        try:
+            resp = hid_dev.read(64, timeout=500)
+        except Exception:
+            resp = None
+        if not resp:
+            time.sleep(0.01)
+            continue
+
+        # Accept if the first 5 bytes echo what we sent.
+        if len(resp) >= 5 and bytes(resp[:5]) == echo:
+            # The pad acknowledges INIT before its display engine is ready to
+            # accept pixel data; streaming immediately after a fresh
+            # enumeration timed out the first image write ("Connection timed
+            # out", issue #43). A short settle lets the firmware come up.
+            time.sleep(0.25)
+            ack_received = True
+            break
+
+    if not ack_received:
+        raise RuntimeError("DisplayPad did not respond to INIT")
 
 
 def _upload_button(usb_dev, hid_dev, key_index, bgr_pixels, key_events=None):

--- a/shared/config.py
+++ b/shared/config.py
@@ -842,11 +842,18 @@ def _clear_displaypad_fullscreen():
         pass
 
 
-def _load_displaypad_actions():
-    """Return list of 12 dicts with 'type' and 'action' keys."""
+def _load_displaypad_actions(page=0):
+    """Return list of 12 dicts with 'type' and 'action' keys for the given
+    DisplayPad page (0 = main page, matching self._current_page in the
+    DisplayPad panel). Sub-page actions are stored separately (see
+    _load_displaypad_pages) so plugins that only ever asked for the main
+    page's actions used to miss anything assigned on a sub-page."""
     default = [{"type": "none", "action": ""} for _ in range(12)]
     try:
-        data = _read_json(DISPLAYPAD_ACTIONS_FILE)
+        if page:
+            data = _load_displaypad_pages().get(str(page), {}).get("actions", [])
+        else:
+            data = _read_json(DISPLAYPAD_ACTIONS_FILE)
         for i in range(12):
             if i < len(data):
                 default[i].update(data[i])

--- a/shared/plugin_api.py
+++ b/shared/plugin_api.py
@@ -93,6 +93,25 @@ class PluginContext:
         if dp and hasattr(dp, "push_plugin_image"):
             dp.push_plugin_image(key_index, pil_image)
 
+    def get_displaypad_current_page(self):
+        """Return the DisplayPad's currently active page number (0 = main
+        page), or 0 if the DisplayPad isn't connected. Use this instead of
+        assuming page 0 so widgets/actions assigned on a sub-page are found.
+        """
+        dp = self.get_displaypad()
+        return getattr(dp, "_current_page", 0) if dp else 0
+
+    def get_displaypad_actions(self, page=None):
+        """Return the 12 button actions for a DisplayPad page. Defaults to
+        whichever page is currently on screen, so a plugin's "which button
+        am I assigned to" lookup works on sub-pages too, not just the main
+        page.
+        """
+        from shared.config import _load_displaypad_actions
+        if page is None:
+            page = self.get_displaypad_current_page()
+        return _load_displaypad_actions(page)
+
     # ── Action registration ───────────────────────────────────────────────────
 
     def register_action_type(self, type_id, label, handler, value_options=None):
@@ -110,5 +129,6 @@ class PluginContext:
         self._pm._action_types[type_id] = {
             "label": label,
             "handler": handler,
+            "owner": getattr(self._pm, "_loading_pid", None),
             "value_options": value_options,
         }

--- a/shared/plugins.py
+++ b/shared/plugins.py
@@ -6,6 +6,16 @@ import importlib.util
 
 from shared.config import CONFIG_DIR, PLUGINS_DISABLED_FILE
 
+# Set BASECAMP_PAGE_DEBUG=1 in the environment to trace page-scoped
+# start/stop decisions (also toggles matching trace lines in
+# devices/displaypad/panel.py and page-bound widget plugins). Off by default.
+_DEBUG = os.environ.get("BASECAMP_PAGE_DEBUG", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _dbg(msg):
+    if _DEBUG:
+        print(msg, flush=True)
+
 PLUGINS_DIR = os.path.join(CONFIG_DIR, "plugins")
 
 
@@ -18,6 +28,9 @@ class PluginManager:
         self._action_types = {}  # type_id -> {"label", "handler"}
         self._disabled = set()   # set of disabled plugin IDs
         self._errors = {}        # id -> error string
+        self._running = {}       # id -> bool, service plugins currently start()-ed
+        self._loading_pid = None  # set while instantiating a plugin, so
+                                   # register_action_type() can tag ownership
         self._load_disabled()
 
     def _load_disabled(self):
@@ -76,8 +89,12 @@ class PluginManager:
             spec = importlib.util.spec_from_file_location(f"plugins.{pid}", mod_path)
             mod = importlib.util.module_from_spec(spec)
             sys.modules[f"plugins.{pid}"] = mod
-            spec.loader.exec_module(mod)
-            instance = mod.Plugin(context)
+            self._loading_pid = pid  # so ctx.register_action_type can tag ownership
+            try:
+                spec.loader.exec_module(mod)
+                instance = mod.Plugin(context)
+            finally:
+                self._loading_pid = None
             self._instances[pid] = instance
             self._errors.pop(pid, None)
             print(f"[Plugin] Loaded: {info.get('name', pid)} v{info.get('version', '?')}")
@@ -118,6 +135,7 @@ class PluginManager:
                     inst.stop()
                 except Exception:
                     pass
+            self._running.pop(pid, None)
             # Remove any action types this plugin registered
             to_remove = [tid for tid, d in self._action_types.items()
                          if getattr(d.get("handler"), "__self__", None) is inst]
@@ -137,6 +155,7 @@ class PluginManager:
                     inst.stop()
                 except Exception:
                     pass
+            self._running.pop(pid, None)
             # Remove action types registered by old instance
             to_remove = [tid for tid, d in self._action_types.items()
                          if getattr(d.get("handler"), "__self__", None) is inst]
@@ -153,18 +172,26 @@ class PluginManager:
         # Re-load
         if not self._load_one(pid, info, self._context):
             return False
-        # Re-start service if applicable
+        # Re-start service if applicable (only if not bound to a button on a
+        # page that isn't currently showing)
         new_inst = self._instances.get(pid)
         if new_inst:
             ptypes = info.get("type", "")
             if isinstance(ptypes, str):
                 ptypes = [ptypes]
-            if "service" in ptypes and hasattr(new_inst, "start"):
-                try:
-                    new_inst.start()
-                except Exception as e:
-                    print(f"[Plugin] Failed to start {pid}: {e}")
+            if "service" in ptypes:
+                if self._owns_a_button(pid) and pid not in self._bound_plugins_for_page(self._current_page()):
+                    pass  # its button is on a different page -- stays off until shown
+                else:
+                    self._start_pid(pid, new_inst, info)
         return True
+
+    def _current_page(self):
+        """Best-effort lookup of the DisplayPad's active page via the stored
+        plugin context (defaults to 0 if unavailable)."""
+        ctx = getattr(self, "_context", None)
+        get_page = getattr(ctx, "get_displaypad_current_page", None)
+        return get_page() if callable(get_page) else 0
 
     def enable_plugin(self, pid):
         """Enable a plugin. Loads it immediately if possible."""
@@ -179,11 +206,11 @@ class PluginManager:
                     ptypes = info.get("type", "")
                     if isinstance(ptypes, str):
                         ptypes = [ptypes]
-                    if "service" in ptypes and hasattr(inst, "start"):
-                        try:
-                            inst.start()
-                        except Exception as e:
-                            print(f"[Plugin] Failed to start {pid}: {e}")
+                    if "service" in ptypes:
+                        if self._owns_a_button(pid) and pid not in self._bound_plugins_for_page(self._current_page()):
+                            pass
+                        else:
+                            self._start_pid(pid, inst, info)
 
     # ── Panel plugins ─────────────────────────────────────────────────────────
 
@@ -239,21 +266,95 @@ class PluginManager:
                 result.append((s, s))
         return result
 
+    # ── DisplayPad page-scoped services ───────────────────────────────────────
+    #
+    # A service plugin that also registers an action type (e.g. Now Playing,
+    # via register_action_type) is "page-bound": it only makes sense to run
+    # while a button on the currently visible DisplayPad page has that action
+    # type assigned. Such plugins are started/stopped with their normal
+    # start()/stop() lifecycle as the user switches pages — no extra hook is
+    # required in the plugin interface. A service plugin that registers no
+    # action type at all (e.g. a background socket server) is treated as
+    # global and simply runs for the whole app lifetime, as before.
+
+    def _owns_a_button(self, pid):
+        """True if this plugin registered at least one action type."""
+        return any(d.get("owner") == pid for d in self._action_types.values())
+
+    def _bound_plugins_for_page(self, page):
+        """Return the set of plugin ids whose registered action type is
+        assigned to some button on the given DisplayPad page."""
+        from shared.config import _load_displaypad_actions
+        actions = _load_displaypad_actions(page)
+        assigned = {a.get("type") for a in actions if a.get("type") not in (None, "none")}
+        bound = set()
+        for tid in assigned:
+            entry = self._action_types.get(tid)
+            if entry and entry.get("owner"):
+                bound.add(entry["owner"])
+        return bound
+
+    def _start_pid(self, pid, inst, info, reason=""):
+        if not hasattr(inst, "start"):
+            return
+        try:
+            inst.start()
+            self._running[pid] = True
+            print(f"[Plugin] Started service{reason}: {info.get('name', pid)}")
+        except Exception as e:
+            print(f"[Plugin] Failed to start {pid}: {e}")
+
+    def _stop_pid(self, pid, inst, info, reason=""):
+        if not hasattr(inst, "stop"):
+            return
+        try:
+            inst.stop()
+        except Exception:
+            pass
+        self._running[pid] = False
+        print(f"[Plugin] Stopped service{reason}: {info.get('name', pid)}")
+
+    def sync_services_for_page(self, page):
+        """Call this whenever the DisplayPad's active page changes. Stops
+        page-bound service plugins whose button isn't on the new page and
+        starts the ones whose button is — using their own start()/stop()."""
+        bound = self._bound_plugins_for_page(page)
+        _dbg(f"[DBG PluginManager] sync_services_for_page({page}): bound={bound} "
+             f"running={dict(self._running)}")
+        for pid, inst in list(self._instances.items()):
+            info = self._manifests.get(pid, {})
+            ptypes = info.get("type", "")
+            if isinstance(ptypes, str):
+                ptypes = [ptypes]
+            if "service" not in ptypes or not self._owns_a_button(pid):
+                continue  # not a service, or a global service -- leave alone
+            should_run = pid in bound
+            is_running = self._running.get(pid, False)
+            _dbg(f"[DBG PluginManager]   {pid}: should_run={should_run} is_running={is_running}")
+            if should_run and not is_running:
+                self._start_pid(pid, inst, info, f" (page {page})")
+            elif not should_run and is_running:
+                self._stop_pid(pid, inst, info, f" (button not on page {page})")
+
+
     # ── Service lifecycle ─────────────────────────────────────────────────────
 
     def start_services(self):
-        """Call start() on all service-type plugins."""
+        """Call start() on all service-type plugins. A plugin that binds to a
+        specific DisplayPad button only starts if that button is on the
+        page shown at launch (page 0); it will start later via
+        sync_services_for_page() once its page becomes active. A plugin with
+        no button binding is global and always starts with the app."""
         for pid, inst in self._instances.items():
             info = self._manifests[pid]
             ptypes = info.get("type", "")
             if isinstance(ptypes, str):
                 ptypes = [ptypes]
-            if "service" in ptypes and hasattr(inst, "start"):
-                try:
-                    inst.start()
-                    print(f"[Plugin] Started service: {info.get('name', pid)}")
-                except Exception as e:
-                    print(f"[Plugin] Failed to start {pid}: {e}")
+            if "service" not in ptypes:
+                continue
+            if self._owns_a_button(pid) and pid not in self._bound_plugins_for_page(0):
+                continue
+            self._start_pid(pid, inst, info)
 
     def shutdown(self):
         """Call stop() on all plugins that have it."""
@@ -263,3 +364,4 @@ class PluginManager:
                     inst.stop()
                 except Exception:
                     pass
+                self._running[pid] = False


### PR DESCRIPTION
Upon switching pages plugins on the old page kept running and plugins on the new page were not started.
Resolved by stopping all service plugins on page swtich and starting the plugins on the new page explicitly.
Also avoid that plugins render things if their page is not visible any mare (race condition) and that plugins write to their own page, not page 0