### PR TITLE
Named pages

### DIFF
--- a/devices/displaypad/panel.py
+++ b/devices/displaypad/panel.py
@@ -37,6 +37,17 @@ from shared.config import (
     _load_displaypad_page_timeouts, _save_displaypad_page_timeouts,
 )
 
+# Set BASECAMP_PAGE_DEBUG=1 in the environment to trace page-switch/upload
+# decisions (also toggles matching trace lines in shared/plugins.py and
+# page-bound widget plugins). Off by default.
+_PAGE_DEBUG = os.environ.get("BASECAMP_PAGE_DEBUG", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _dbg(msg):
+    if _PAGE_DEBUG:
+        print(msg, flush=True)
+
+
 try:
     import hid
     HID_AVAILABLE = True
@@ -2610,10 +2621,29 @@ class DisplayPadPanel(ctk.CTkFrame):
         if self._fullscreen_group:
             self._page_fullscreen.setdefault(old_page, None)  # keep existing path
 
+        _dbg(f"[DBG switch] {old_page} -> {page_num} | saved page_images[{old_page}]={self._page_images[old_page]}")
+
         self._current_page = page_num
+
+        # Start/stop page-bound service plugins using their normal start()/
+        # stop() lifecycle: a plugin whose button was on the page we're
+        # leaving gets stop()'d (it was otherwise still polling and painting
+        # over that key index on the new page, since keys are shared
+        # hardware slots across pages), and a plugin whose button is on the
+        # page we're entering gets start()'d right away.
+        pm = getattr(self._app, "_plugin_manager", None)
+        if pm:
+            try:
+                pm.sync_services_for_page(page_num)
+            except Exception as e:
+                print(f"[Plugin] sync_services_for_page failed: {e}")
+
+        _dbg(f"[DBG switch] after sync_services_for_page({page_num}): "
+              f"page_images[{page_num}]={self._page_images.get(page_num)}")
 
         # Load new page
         self._images = dict(self._page_images.get(page_num, {}))
+        _dbg(f"[DBG switch] loaded self._images for page {page_num} = {self._images}")
         self._gif_frames = {}
         self._gui_frames_sm = {}
         self._gui_fidx = {}
@@ -3184,6 +3214,7 @@ class DisplayPadPanel(ctk.CTkFrame):
     def _start_upload(self):
         assigned = {int(k): v for k, v in self._images.items()
                     if v and os.path.exists(v)}
+        _dbg(f"[DBG upload] page={self._current_page} uploading assigned={assigned}")
         # Include gif_frames keys not in _images (fullscreen GIF loaded without individual paths)
         for k in self._gif_frames:
             if k not in assigned:
@@ -3502,6 +3533,7 @@ class DisplayPadPanel(ctk.CTkFrame):
         """
         if not (0 <= key_index <= 11):
             return
+        _dbg(f"[DBG push_plugin_image] key={key_index} current_page={self._current_page}")
         img = pil_image.convert("RGB").resize((ICON_SIZE, ICON_SIZE), Image.LANCZOS)
         rot = self._rotation
         if rot:

--- a/devices/displaypad/panel.py
+++ b/devices/displaypad/panel.py
@@ -35,7 +35,20 @@ from shared.config import (
     _load_displaypad_brightness, _save_displaypad_brightness,
     _load_displaypad_debounce, _save_displaypad_debounce,
     _load_displaypad_page_timeouts, _save_displaypad_page_timeouts,
+    _load_displaypad_page_names, _save_displaypad_page_names,
+    _create_displaypad_page, _rename_displaypad_page, _delete_displaypad_page,
 )
+
+# Set BASECAMP_PAGE_DEBUG=1 in the environment to trace page-switch/upload
+# decisions (also toggles matching trace lines in shared/plugins.py and
+# page-bound widget plugins). Off by default.
+_PAGE_DEBUG = os.environ.get("BASECAMP_PAGE_DEBUG", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _dbg(msg):
+    if _PAGE_DEBUG:
+        print(msg, flush=True)
+
 
 try:
     import hid
@@ -530,6 +543,19 @@ def _make_placeholder(size):
     return ctk.CTkImage(light_image=img, dark_image=img, size=(size, size))
 
 
+def _prompt_page_name(app, prompt_key, title_key, initial=""):
+    """Modal one-line text prompt for a page name (#52), used both to create
+    a brand-new standalone page and to rename an existing one. Returns the
+    entered name, or None if cancelled / left blank."""
+    dlg = ctk.CTkInputDialog(text=app.T(prompt_key), title=app.T(title_key))
+    try:
+        val = dlg.get_input()
+    except Exception:
+        val = None
+    val = (val or "").strip()
+    return val or None
+
+
 # ── Image management dialog ───────────────────────────────────────────────────
 
 _DIALOG_TILE  = 90   # thumbnail size in dialog
@@ -597,14 +623,19 @@ class DisplayPadImageDialog(ctk.CTkToplevel):
         pages = self._panel._get_available_pages()
         page_labels = [self._panel._get_page_name(p) for p in pages]
         self._page_list = pages
+        newlbl = self._app.T("dp_new_page")
         self._page_selector = ctk.CTkOptionMenu(
-            header, values=page_labels,
+            header, values=page_labels + [newlbl],
             fg_color=BG2, button_color=BLUE, button_hover_color="#0884be",
             text_color=FG, font=("Helvetica", 11), width=100, height=28,
             command=self._on_page_change)
         cur = self._panel._current_page
         self._page_selector.set(self._panel._get_page_name(cur))
         self._page_selector.pack(side="right")
+        ctk.CTkButton(
+            header, text="✎", width=28, height=28,
+            fg_color=BG2, hover_color="#333a44", text_color=FG,
+            command=self._on_rename_page).pack(side="right", padx=(0, 6))
 
         # 6 × 2 grid of tiles
         grid = ctk.CTkFrame(self, fg_color="transparent")
@@ -882,7 +913,16 @@ class DisplayPadImageDialog(ctk.CTkToplevel):
                 text=self._app.T("dp_fullscreen_static", name=os.path.basename(path)), text_color=GRN)
 
     def _on_page_change(self, label):
-        """Switch the image dialog to show a different page's images."""
+        """Switch the image dialog to show a different page's images, or
+        create a brand-new standalone page if 'New page...' was picked (#52)."""
+        if label == self._app.T("dp_new_page"):
+            name = _prompt_page_name(self._app, "dp_page_name_prompt", "dp_page_name_title")
+            if not name:
+                self._page_selector.set(self._panel._get_page_name(self._panel._current_page))
+                return
+            pid = self._panel._create_named_page(name)
+            self._refresh_page_selector(select=pid)
+            return
         for p, lbl in zip(self._page_list,
                           [self._panel._get_page_name(x)
                            for x in self._page_list]):
@@ -900,6 +940,31 @@ class DisplayPadImageDialog(ctk.CTkToplevel):
                 for idx in range(NUM_KEYS):
                     self._refresh_tile(idx)
                 break
+
+    def _refresh_page_selector(self, select=None):
+        """Rebuild the page dropdown's values after a page was created or
+        renamed (#52), and switch to `select` if given."""
+        pages = self._panel._get_available_pages()
+        self._page_list = pages
+        page_labels = [self._panel._get_page_name(p) for p in pages]
+        newlbl = self._app.T("dp_new_page")
+        self._page_selector.configure(values=page_labels + [newlbl])
+        target = select if select is not None else self._panel._current_page
+        self._page_selector.set(self._panel._get_page_name(target))
+        if select is not None and select != self._panel._current_page:
+            self._on_page_change(self._panel._get_page_name(select))
+
+    def _on_rename_page(self):
+        """Rename the page currently shown in this dialog (#52). Main (page
+        0) is renamable too -- it's just the page the app opens on."""
+        cur = self._panel._current_page
+        name = _prompt_page_name(
+            self._app, "dp_page_name_prompt", "dp_rename_page_title",
+            initial=self._panel._get_page_name(cur))
+        if not name:
+            return
+        self._panel._rename_page(cur, name)
+        self._refresh_page_selector()
 
     def destroy(self):
         # Auto-upload when dialog closes. Guard against the panel being
@@ -1030,8 +1095,10 @@ class DisplayPadActionsDialog(ctk.CTkToplevel):
             act = actions[i] if i < len(actions) else {"type": "none", "action": ""}
             btype = act.get("type", "none")
             cmd   = act.get("action", "")
-            # Remember an existing 'page' target so the picker can preselect it.
-            self._page_targets[i] = act.get("target") if btype == "page" else None
+            # Remember an existing 'page' target (by name, #52) so the picker
+            # can preselect it -- resolved to an id right away so it behaves
+            # exactly like the "new"/int values the picker itself produces.
+            self._page_targets[i] = self._panel._page_target(act, i) if btype == "page" else None
 
             self._act_type[i].set(btype)
             self._act_cmd[i].set(cmd)
@@ -1189,12 +1256,17 @@ class DisplayPadActionsDialog(ctk.CTkToplevel):
         # Page selector
         pages = self._panel._get_available_pages()
         page_labels = [self._panel._get_page_name(p) for p in pages]
+        newlbl = self._app.T("dp_new_page")
         self._page_selector = ctk.CTkOptionMenu(
-            header, values=page_labels,
+            header, values=page_labels + [newlbl],
             fg_color=BG2, button_color=BLUE, button_hover_color="#0884be",
             text_color=FG, font=("Helvetica", 11), width=100, height=28,
             command=self._on_page_change)
         self._page_selector.pack(side="right")
+        ctk.CTkButton(
+            header, text="✎", width=28, height=28,
+            fg_color=BG2, hover_color="#333a44", text_color=FG,
+            command=self._on_rename_page).pack(side="right", padx=(0, 6))
         self._page_list = pages
 
         # ── Per-page auto-timeout (issue #45) ─────────────────────────────────
@@ -1395,6 +1467,14 @@ class DisplayPadActionsDialog(ctk.CTkToplevel):
         ).pack(fill="x", padx=12, pady=(0, 12))
 
     def _on_page_change(self, label):
+        if label == self._app.T("dp_new_page"):
+            name = _prompt_page_name(self._app, "dp_page_name_prompt", "dp_page_name_title")
+            if not name:
+                self._page_selector.set(self._panel._get_page_name(self._page))
+                return
+            pid = self._panel._create_named_page(name)
+            self._refresh_page_selector(select=pid)
+            return
         for p, lbl in zip(self._page_list,
                           [self._panel._get_page_name(x)
                            for x in self._page_list]):
@@ -1408,6 +1488,30 @@ class DisplayPadActionsDialog(ctk.CTkToplevel):
                 except Exception:
                     pass
                 break
+
+    def _refresh_page_selector(self, select=None):
+        """Rebuild the page dropdown's values after a page was created or
+        renamed (#52), and switch the editor to `select` if given."""
+        pages = self._panel._get_available_pages()
+        self._page_list = pages
+        page_labels = [self._panel._get_page_name(p) for p in pages]
+        newlbl = self._app.T("dp_new_page")
+        self._page_selector.configure(values=page_labels + [newlbl])
+        target = select if select is not None else self._page
+        self._page_selector.set(self._panel._get_page_name(target))
+        if select is not None and select != self._page:
+            self._on_page_change(self._panel._get_page_name(select))
+
+    def _on_rename_page(self):
+        """Rename the page currently open in the editor (#52). Main (page 0)
+        is renamable too -- it's just the page the app opens on."""
+        name = _prompt_page_name(
+            self._app, "dp_page_name_prompt", "dp_rename_page_title",
+            initial=self._panel._get_page_name(self._page))
+        if not name:
+            return
+        self._panel._rename_page(self._page, name)
+        self._refresh_page_selector()
 
     # ── Per-page auto-timeout controls (issue #45) ────────────────────────────
     _TIMEOUT_MODES = ["off", "after", "idle"]
@@ -1444,7 +1548,12 @@ class DisplayPadActionsDialog(ctk.CTkToplevel):
         tgt = to.get("target", "prev")
         sel = None
         for lbl, val in mapping.items():
-            if val == tgt:
+            if val == "prev":
+                match = (tgt == "prev")
+            else:
+                # tgt may be a legacy int id or (#52) a persisted page name.
+                match = (tgt == val or tgt == self._panel._get_page_name(val))
+            if match:
                 sel = lbl
                 break
         self._to_target_menu.set(sel or self._app.T("dp_timeout_prev"))
@@ -1461,7 +1570,10 @@ class DisplayPadActionsDialog(ctk.CTkToplevel):
         except (ValueError, TypeError):
             secs = 10
         _labels, mapping = self._timeout_target_options()
-        tgt = mapping.get(self._to_target_menu.get(), "prev")
+        picked = mapping.get(self._to_target_menu.get(), "prev")
+        # Store by name (#52), like every other page reference; "prev" is
+        # kept as-is since it's a mode, not a page.
+        tgt = picked if picked == "prev" else self._panel._get_page_name(picked)
         if mode == "off":
             self._panel._page_timeout.pop(self._page, None)
         else:
@@ -1864,11 +1976,10 @@ class DisplayPadActionsDialog(ctk.CTkToplevel):
             step = {"type": sectype, "action": secval}
             if sectype == "page":
                 # 'also on press → go to page' (#17): the entry holds a page
-                # name; resolve it to a page id so the chain can navigate.
-                _lbls, mapping = self._page_target_options()
-                tgt = mapping.get(secval)
-                if isinstance(tgt, int):
-                    step["target"] = tgt
+                # name, stored directly (#52) -- _page_target() resolves it
+                # back to an id when the chain actually runs.
+                if self._panel._page_id_by_name(secval) is not None:
+                    step["target"] = secval
                     extra = [step]
                 # unresolved / 'New page' name → skip (nothing to jump to)
             elif secval:
@@ -1881,10 +1992,8 @@ class DisplayPadActionsDialog(ctk.CTkToplevel):
         if dbltype and dbltype != "none":
             step = {"type": dbltype, "action": dblval}
             if dbltype == "page":
-                _l2, map2 = self._page_target_options()
-                tgt2 = map2.get(dblval)
-                if isinstance(tgt2, int):
-                    step["target"] = tgt2
+                if self._panel._page_id_by_name(dblval) is not None:
+                    step["target"] = dblval
                     double = step
             elif dblval:
                 double = step
@@ -2289,12 +2398,23 @@ class DisplayPadPanel(ctk.CTkFrame):
             return (a.get("type", "none"), a.get("action", ""))
         return ("none", "")
 
-    @staticmethod
-    def _page_target(act, idx):
-        """Resolve a 'page' action's destination page id. New configs carry an
-        explicit integer 'target'; legacy main-page actions had no target and
-        mapped to the fixed sub-page idx+1, so fall back to that (#30 migration)."""
+    def _page_target(self, act, idx):
+        """Resolve a 'page' action's destination page id. Targets are stored
+        by NAME (a string, resolved against the page-name registry) so they
+        keep working even as page ids get minted/reordered elsewhere and so
+        they match what's shown in the page picker (#52). Legacy configs
+        stored a raw integer id, which is still accepted here; very old
+        main-page-only actions had no target at all and mapped to the fixed
+        sub-page idx+1, so that fallback is kept too."""
         t = act.get("target")
+        if isinstance(t, str):
+            pid = self._page_id_by_name(t)
+            if pid is not None:
+                return pid
+            try:
+                return int(t)
+            except ValueError:
+                return idx + 1
         try:
             return int(t)
         except (TypeError, ValueError):
@@ -2302,10 +2422,12 @@ class DisplayPadPanel(ctk.CTkFrame):
 
     def _all_page_ids(self):
         """Every page id that exists or is referenced: 0, any page with stored
-        actions/images, and every 'page' action target anywhere."""
+        actions/images, every 'page' action target anywhere, and every page
+        registered by name even if nothing points at it yet (#52)."""
         ids = {0}
         ids.update(self._page_actions.keys())
         ids.update(self._page_images.keys())
+        ids.update(_load_displaypad_page_names().keys())
         for page, acts in self._page_actions.items():
             for i, act in enumerate(acts):
                 if act.get("type") == "page":
@@ -2357,7 +2479,7 @@ class DisplayPadPanel(ctk.CTkFrame):
             return
         acts = [dict(a) for a in _DEFAULT_ACTIONS]
         acts[0] = {"type": "page", "action": self.T("dp_page_back"),
-                   "target": int(back_to), "icon": self._back_icon}
+                   "target": self._get_page_name(int(back_to)), "icon": self._back_icon}
         self._page_actions[page_id] = acts
         self._page_images.setdefault(page_id, {})
         self._save_sub_pages()
@@ -2365,10 +2487,27 @@ class DisplayPadPanel(ctk.CTkFrame):
     def _gc_orphan_pages(self):
         """Drop pages that nothing navigates to and that hold no content — e.g.
         a page minted when the user picked 'New page' but then retargeted the
-        button to an existing page (#30). Conservative: never touches page 0 or
-        the current page, keeps any page with an image/fullscreen or a non-default
-        action (the auto back button on K1 doesn't count as content)."""
-        referenced = {0, self._current_page}
+        button to an existing page (#30). Conservative: never touches page 0, the
+        current page, or any page registered by name (#52 -- a person may have
+        pre-created it on purpose and not gotten around to using it yet). Also
+        keeps any page with an image/fullscreen or a non-default action (the
+        auto back button on K1 doesn't count as content)."""
+        registered = set(_load_displaypad_page_names().keys())
+        referenced = {0, self._current_page} | registered
+
+        def _resolve(tgt, idx=0):
+            if isinstance(tgt, str):
+                pid = self._page_id_by_name(tgt)
+                if pid is not None:
+                    return pid
+                try:
+                    return int(tgt)
+                except ValueError:
+                    return None
+            if isinstance(tgt, int):
+                return tgt
+            return None
+
         for page, acts in self._page_actions.items():
             for i, a in enumerate(acts):
                 if a.get("type") == "page":
@@ -2376,17 +2515,20 @@ class DisplayPadPanel(ctk.CTkFrame):
                 # A page targeted only by an 'also on press' chain step (#17) or a
                 # double-click action (#47) is still referenced — don't GC it.
                 for step in (a.get("actions") or []):
-                    if step.get("type") == "page" and isinstance(step.get("target"), int):
-                        referenced.add(step["target"])
+                    if step.get("type") == "page":
+                        pid = _resolve(step.get("target"))
+                        if pid is not None:
+                            referenced.add(pid)
                 dbl = a.get("double")
-                if (isinstance(dbl, dict) and dbl.get("type") == "page"
-                        and isinstance(dbl.get("target"), int)):
-                    referenced.add(dbl["target"])
+                if isinstance(dbl, dict) and dbl.get("type") == "page":
+                    pid = _resolve(dbl.get("target"))
+                    if pid is not None:
+                        referenced.add(pid)
         # A page reachable only as an auto-timeout destination is referenced too (#45).
         for _p, to in (self._page_timeout or {}).items():
-            tgt = (to or {}).get("target")
-            if isinstance(tgt, int):
-                referenced.add(tgt)
+            pid = _resolve((to or {}).get("target"))
+            if pid is not None:
+                referenced.add(pid)
         removed = False
         for p in list(self._page_actions.keys()):
             if p in referenced or p == 0:
@@ -2456,15 +2598,15 @@ class DisplayPadPanel(ctk.CTkFrame):
         # ── 'page' action: resolve/allocate target + custom icon ──────────────
         if btype == "page":
             if target in (None, "", "new"):
-                target = (old.get("target")
-                          if old.get("type") == "page" and isinstance(old.get("target"), int)
+                target = (self._page_target(old, idx)
+                          if old.get("type") == "page" and old.get("target") not in (None, "")
                           else self._mint_page_id())
             target = int(target)
-            entry["target"] = target
+            self._ensure_page(target, back_to=page)
+            entry["target"] = self._get_page_name(target)
             keep_icon = icon or (old.get("icon") if old.get("type") == "page" else None)
             if keep_icon:
                 entry["icon"] = keep_icon
-            self._ensure_page(target, back_to=page)
 
         actions[idx] = entry
         self._page_images.setdefault(page, {})
@@ -2610,10 +2752,29 @@ class DisplayPadPanel(ctk.CTkFrame):
         if self._fullscreen_group:
             self._page_fullscreen.setdefault(old_page, None)  # keep existing path
 
+        _dbg(f"[DBG switch] {old_page} -> {page_num} | saved page_images[{old_page}]={self._page_images[old_page]}")
+
         self._current_page = page_num
+
+        # Start/stop page-bound service plugins using their normal start()/
+        # stop() lifecycle: a plugin whose button was on the page we're
+        # leaving gets stop()'d (it was otherwise still polling and painting
+        # over that key index on the new page, since keys are shared
+        # hardware slots across pages), and a plugin whose button is on the
+        # page we're entering gets start()'d right away.
+        pm = getattr(self._app, "_plugin_manager", None)
+        if pm:
+            try:
+                pm.sync_services_for_page(page_num)
+            except Exception as e:
+                print(f"[Plugin] sync_services_for_page failed: {e}")
+
+        _dbg(f"[DBG switch] after sync_services_for_page({page_num}): "
+              f"page_images[{page_num}]={self._page_images.get(page_num)}")
 
         # Load new page
         self._images = dict(self._page_images.get(page_num, {}))
+        _dbg(f"[DBG switch] loaded self._images for page {page_num} = {self._images}")
         self._gif_frames = {}
         self._gui_frames_sm = {}
         self._gui_fidx = {}
@@ -2677,18 +2838,100 @@ class DisplayPadPanel(ctk.CTkFrame):
         return sorted(self._all_page_ids())
 
     def _get_page_name(self, p):
-        """Return the user-defined name for a page, falling back to 'Page N'.
-        The name is taken from the label of any 'page' action that targets it
-        (searched across all pages, not just the main page)."""
+        """Return the persisted name for a page. Page 0 is just another
+        entry in the same registry -- it only happens to be the page the
+        app opens on -- defaulting to a translated 'Main' the first time
+        (after which it's stored data like any other page and can be
+        renamed). A page with no registry entry yet but that's targeted by
+        an existing 'page' action (pre-#52 configs) has its button-derived
+        label adopted into the registry once, so the name becomes durable
+        instead of being re-derived (and able to disappear) every time."""
+        names = _load_displaypad_page_names()
+        if p in names:
+            return names[p]
         if p == 0:
-            return self.T("dp_page_main")
+            default = self.T("dp_page_main")
+            names[0] = default
+            _save_displaypad_page_names(names)
+            return default
         for page, acts in self._page_actions.items():
             for i, act in enumerate(acts):
                 if act.get("type") == "page" and self._page_target(act, i) == p:
                     name = (act.get("action") or "").strip()
                     if name:
+                        names[p] = name
+                        _save_displaypad_page_names(names)
                         return name
-        return f"Page {p}"
+        fallback = f"Page {p}"
+        names[p] = fallback
+        _save_displaypad_page_names(names)
+        return fallback
+
+    def _page_id_by_name(self, name):
+        """Resolve a page name back to its id, or None if no page has that
+        name right now (e.g. it was renamed or deleted elsewhere)."""
+        for pid, nm in _load_displaypad_page_names().items():
+            if nm == name:
+                return pid
+        return None
+
+    def _create_named_page(self, name):
+        """Register a brand-new page that isn't targeted by any button yet
+        (#52) -- it exists purely because it's in the name registry, and
+        _gc_orphan_pages() knows to leave it alone."""
+        name = (name or "").strip() or f"Page {self._mint_page_id()}"
+        pid = _create_displaypad_page(name, existing_ids=self._all_page_ids())
+        self._page_actions.setdefault(pid, [dict(a) for a in _DEFAULT_ACTIONS])
+        self._page_images.setdefault(pid, {})
+        self._save_sub_pages()
+        return pid
+
+    def _rename_page(self, page_id, name):
+        """Rename a page and update every stored reference to it (#52).
+        References are stored by name, so without this cascade a button
+        that pointed at the old name would silently stop resolving the
+        moment the page got renamed -- that would make name-based
+        references *less* durable than plain ids, not more."""
+        page_id = int(page_id)
+        name = (name or "").strip()
+        if not name:
+            return
+        old_name = self._get_page_name(page_id)
+        _rename_displaypad_page(page_id, name)
+        if old_name == name:
+            return
+
+        def _retarget(step):
+            if isinstance(step, dict) and step.get("target") == old_name:
+                step["target"] = name
+                return True
+            return False
+
+        changed_actions = False
+        for page, acts in self._page_actions.items():
+            for act in acts:
+                if not isinstance(act, dict):
+                    continue
+                if act.get("type") == "page" and _retarget(act):
+                    changed_actions = True
+                for step in (act.get("actions") or []):
+                    if step.get("type") == "page" and _retarget(step):
+                        changed_actions = True
+                dbl = act.get("double")
+                if isinstance(dbl, dict) and dbl.get("type") == "page" and _retarget(dbl):
+                    changed_actions = True
+        if changed_actions:
+            if 0 in self._page_actions:
+                _save_displaypad_actions(self._page_actions[0])
+            self._save_sub_pages()
+
+        changed_timeout = False
+        for _p, to in (self._page_timeout or {}).items():
+            if isinstance(to, dict) and to.get("target") == old_name:
+                to["target"] = name
+                changed_timeout = True
+        if changed_timeout:
+            _save_displaypad_page_timeouts(self._page_timeout)
 
     def _get_extra_actions(self, idx):
         """Extra action steps for button idx (issue #17). Stored as an `actions`
@@ -2787,6 +3030,9 @@ class DisplayPadPanel(ctk.CTkFrame):
         tgt = to.get("target", 0)
         if tgt == "prev":
             tgt = self._prev_page
+        elif isinstance(tgt, str):
+            pid = self._page_id_by_name(tgt)
+            tgt = pid if pid is not None else 0
         try:
             tgt = int(tgt)
         except (TypeError, ValueError):
@@ -3184,6 +3430,7 @@ class DisplayPadPanel(ctk.CTkFrame):
     def _start_upload(self):
         assigned = {int(k): v for k, v in self._images.items()
                     if v and os.path.exists(v)}
+        _dbg(f"[DBG upload] page={self._current_page} uploading assigned={assigned}")
         # Include gif_frames keys not in _images (fullscreen GIF loaded without individual paths)
         for k in self._gif_frames:
             if k not in assigned:
@@ -3502,6 +3749,7 @@ class DisplayPadPanel(ctk.CTkFrame):
         """
         if not (0 <= key_index <= 11):
             return
+        _dbg(f"[DBG push_plugin_image] key={key_index} current_page={self._current_page}")
         img = pil_image.convert("RGB").resize((ICON_SIZE, ICON_SIZE), Image.LANCZOS)
         rot = self._rotation
         if rot:

--- a/devices/displaypad/panel.py
+++ b/devices/displaypad/panel.py
@@ -130,18 +130,7 @@ def _open_interfaces():
                 hid_dev.close()
                 raise RuntimeError("DisplayPad not found via PyUSB")
             usb.util.claim_interface(usb_dev, 1)
-            # Quiesce the display interface with SET_IDLE(0) before streaming
-            # image data. Windows Base Camp issues SET_IDLE for interfaces 0, 1
-            # and 3; the Linux stack only covered 0 and 3 (hidraw does them),
-            # leaving interface 1 un-idled. A pad that was unplugged/replugged
-            # could then wedge interface 1 and the first upload timed out
-            # (issue #40, from FransM's Windows-vs-Linux capture comparison).
-            # HID class request: bmRequestType=0x21, bRequest=SET_IDLE(0x0A),
-            # wValue=0 (duration 0, report 0), wIndex=interface 1. Best-effort.
-            try:
-                usb_dev.ctrl_transfer(0x21, 0x0A, 0x0000, 1, None, timeout=500)
-            except Exception:
-                pass
+            _init_handshake_ctrl(usb_dev)
             return usb_dev, hid_dev
         except Exception as e:
             last_err = e
@@ -152,6 +141,70 @@ def _open_interfaces():
                     pass
             time.sleep(0.2)
     raise last_err if last_err else RuntimeError("DisplayPad open failed")
+
+
+def _init_handshake_ctrl(usb_dev):
+    """
+    Step 1: temporarily claim IF0 (the keyboard interface). IF0 is only
+    needed for the two control transfers below, so detach its kernel driver
+    first and reattach it afterwards — the keyboard must keep working.
+
+    Step 2: SET_IDLE (bRequest 0x0A, wValue 0) on IF0, IF1 (pixels) and IF3
+    (cmd) to suppress repeated reports when nothing is changing. EPIPE /
+    any failure here just means the interface doesn't support it and is
+    ignored (best-effort, matching warnLibusb's non-fatal handling).
+
+    Step 3: SET_REPORT (output report 3, payload {0x03, 0x01}) on IF0 to
+    enable the device's event reporting mode (verified by USB capture on
+    Windows).
+
+    Step 4: release IF0 and reattach its kernel driver. IF1 stays claimed
+    by us (already claimed by the caller) for the rest of the session.
+    """
+    if0_was_active = False
+    try:
+        if0_was_active = bool(usb_dev.is_kernel_driver_active(0))
+    except Exception:
+        pass
+    if if0_was_active:
+        try:
+            usb_dev.detach_kernel_driver(0)
+        except Exception:
+            pass
+
+    if0_claimed = False
+    try:
+        usb.util.claim_interface(usb_dev, 0)
+        if0_claimed = True
+    except Exception:
+        pass
+
+    def _set_idle(iface):
+        try:
+            usb_dev.ctrl_transfer(0x21, 0x0A, 0x0000, iface, None, timeout=500)
+        except Exception:
+            pass
+
+    if if0_claimed:
+        _set_idle(0)
+    _set_idle(1)  # IF_PIXELS
+    _set_idle(3)  # IF_CMD
+
+    if if0_claimed:
+        try:
+            usb_dev.ctrl_transfer(0x21, 0x09, 0x0203, 0x0000,
+                                   bytes([0x03, 0x01]), timeout=500)
+        except Exception:
+            pass
+        try:
+            usb.util.release_interface(usb_dev, 0)
+        except Exception:
+            pass
+        if if0_was_active:
+            try:
+                usb_dev.attach_kernel_driver(0)
+            except Exception:
+                pass
 
 
 def _close_interfaces(usb_dev, hid_dev):
@@ -170,28 +223,47 @@ def _close_interfaces(usb_dev, hid_dev):
 
 
 def _init_device(hid_dev):
-    """Bring the DisplayPad up by sending INIT and waiting for its 0x11 reply.
+    """Bring the DisplayPad up: send INIT_MSG on IF3 and wait for a matching echo
 
-    After an unplug/replug the pad frequently misses the first INIT: the old
-    code wrote INIT once and then blocked reading for up to 10s before trying
-    again, so recovery was slow and often timed out with "Connection timed out"
-    when the GUI was restarted on a replugged pad (issue #40). Windows Base Camp
-    instead re-sends INIT several times until the pad answers. We do the same —
-    short read windows between frequent re-writes make a missed INIT recover in
-    a fraction of a second instead of stalling."""
-    for attempt in range(15):
-        hid_dev.write(INIT_MSG)
-        for _ in range(10):
-            resp = hid_dev.read(64, timeout=100)
-            if resp and resp[0] == 0x11:
-                # The pad acknowledges INIT before its display engine is ready to
-                # accept pixel data; streaming immediately after a fresh
-                # enumeration timed out the first image write ("Connection timed
-                # out", issue #43). A short settle lets the firmware come up.
-                time.sleep(0.25)
-                return
-        time.sleep(0.1)
-    raise RuntimeError("DisplayPad did not respond to INIT")
+    Send INIT_MSG, then wait up to 500 ms for a reply. The reply is accepted
+    once its first 5 bytes echo what we sent. Retry up to 60 times with a
+    10 ms gap after a failed write or read — the device can be slow to come
+    up after a fresh plug-in (issue #40)."""
+    # INIT_MSG here carries a leading HID report-ID byte (0x00) that
+    # hid_dev.write() needs; the device's raw 64-byte packet — and the echo
+    # it sends back via hid_dev.read() — does not include that byte, so the
+    # comparison is offset by one to line up with init.cpp's INIT_MSG[0:5]
+    # (0x11 0x80 0x00 0x00 0x01).
+    pkt = INIT_MSG
+    echo = pkt[1:6]
+    ack_received = False
+    for _attempt in range(60):
+        try:
+            hid_dev.write(pkt)
+        except Exception:
+            time.sleep(0.01)
+            continue
+
+        try:
+            resp = hid_dev.read(64, timeout=500)
+        except Exception:
+            resp = None
+        if not resp:
+            time.sleep(0.01)
+            continue
+
+        # Accept if the first 5 bytes echo what we sent.
+        if len(resp) >= 5 and bytes(resp[:5]) == echo:
+            # The pad acknowledges INIT before its display engine is ready to
+            # accept pixel data; streaming immediately after a fresh
+            # enumeration timed out the first image write ("Connection timed
+            # out", issue #43). A short settle lets the firmware come up.
+            time.sleep(0.25)
+            ack_received = True
+            break
+
+    if not ack_received:
+        raise RuntimeError("DisplayPad did not respond to INIT")
 
 
 def _upload_button(usb_dev, hid_dev, key_index, bgr_pixels, key_events=None):

--- a/devices/displaypad/panel.py
+++ b/devices/displaypad/panel.py
@@ -16,6 +16,7 @@ import queue
 import threading
 import subprocess
 import tkinter as tk
+from tkinter import messagebox
 import customtkinter as ctk
 from PIL import Image, ImageDraw
 
@@ -556,6 +557,46 @@ def _prompt_page_name(app, prompt_key, title_key, initial=""):
     return val or None
 
 
+_REF_KIND_LABELS = {
+    "action": "dp_ref_kind_action",
+    "also_on_press": "dp_ref_kind_also_on_press",
+    "double_click": "dp_ref_kind_double_click",
+    "timeout": "dp_ref_kind_timeout",
+}
+
+
+def _confirm_delete_page(app, panel, page_id):
+    """Ask for confirmation before deleting a page (#54). If anything still
+    targets it by name, list exactly what and where so the person can
+    decide whether to fix those first or delete anyway. Returns True if the
+    person confirmed the delete."""
+    if page_id == 0:
+        messagebox.showerror(app.T("dp_delete_page_title"), app.T("dp_delete_page_main_error"))
+        return False
+
+    page_name = panel._get_page_name(page_id)
+    refs = panel._find_page_references(page_id)
+    if not refs:
+        return messagebox.askyesno(
+            app.T("dp_delete_page_title"),
+            app.T("dp_delete_page_confirm", name=page_name))
+
+    lines = []
+    for r in refs[:10]:
+        from_name = panel._get_page_name(r["from_page"])
+        kind = app.T(_REF_KIND_LABELS.get(r["kind"], r["kind"]))
+        if r["key"] is None:
+            lines.append(f"\u2022 {from_name} \u2014 {kind}")
+        else:
+            lines.append(f"\u2022 {from_name}, K{r['key'] + 1} \u2014 {kind}")
+    extra = len(refs) - len(lines)
+    if extra > 0:
+        lines.append(app.T("dp_delete_page_more", count=extra))
+    msg = app.T("dp_delete_page_referenced_warning", name=page_name, count=len(refs)) \
+        + "\n\n" + "\n".join(lines)
+    return messagebox.askyesno(app.T("dp_delete_page_title"), msg, icon="warning")
+
+
 # ── Image management dialog ───────────────────────────────────────────────────
 
 _DIALOG_TILE  = 90   # thumbnail size in dialog
@@ -636,6 +677,10 @@ class DisplayPadImageDialog(ctk.CTkToplevel):
             header, text="✎", width=28, height=28,
             fg_color=BG2, hover_color="#333a44", text_color=FG,
             command=self._on_rename_page).pack(side="right", padx=(0, 6))
+        ctk.CTkButton(
+            header, text="🗑", width=28, height=28,
+            fg_color=BG2, hover_color="#4a2222", text_color=FG,
+            command=self._on_delete_page).pack(side="right", padx=(0, 6))
 
         # 6 × 2 grid of tiles
         grid = ctk.CTkFrame(self, fg_color="transparent")
@@ -966,6 +1011,15 @@ class DisplayPadImageDialog(ctk.CTkToplevel):
         self._panel._rename_page(cur, name)
         self._refresh_page_selector()
 
+    def _on_delete_page(self):
+        """Delete the page currently shown in this dialog (#54), after
+        warning if anything still points at it by name."""
+        cur = self._panel._current_page
+        if not _confirm_delete_page(self._app, self._panel, cur):
+            return
+        self._panel._delete_page(cur)
+        self._refresh_page_selector()
+
     def destroy(self):
         # Auto-upload when dialog closes. Guard against the panel being
         # destroyed first during an app shutdown, which would raise TclError.
@@ -1267,6 +1321,10 @@ class DisplayPadActionsDialog(ctk.CTkToplevel):
             header, text="✎", width=28, height=28,
             fg_color=BG2, hover_color="#333a44", text_color=FG,
             command=self._on_rename_page).pack(side="right", padx=(0, 6))
+        ctk.CTkButton(
+            header, text="🗑", width=28, height=28,
+            fg_color=BG2, hover_color="#4a2222", text_color=FG,
+            command=self._on_delete_page).pack(side="right", padx=(0, 6))
         self._page_list = pages
 
         # ── Per-page auto-timeout (issue #45) ─────────────────────────────────
@@ -1512,6 +1570,16 @@ class DisplayPadActionsDialog(ctk.CTkToplevel):
             return
         self._panel._rename_page(self._page, name)
         self._refresh_page_selector()
+
+    def _on_delete_page(self):
+        """Delete the page currently open in the editor (#54), after
+        warning if anything still points at it by name. Always falls back
+        to showing Main afterward, since the page being edited is gone."""
+        page_id = self._page
+        if not _confirm_delete_page(self._app, self._panel, page_id):
+            return
+        self._panel._delete_page(page_id)
+        self._refresh_page_selector(select=0)
 
     # ── Per-page auto-timeout controls (issue #45) ────────────────────────────
     _TIMEOUT_MODES = ["off", "after", "idle"]
@@ -2932,6 +3000,53 @@ class DisplayPadPanel(ctk.CTkFrame):
                 changed_timeout = True
         if changed_timeout:
             _save_displaypad_page_timeouts(self._page_timeout)
+
+    def _find_page_references(self, page_id):
+        """Return every place that targets this page by name: a primary
+        'page' action, an 'also on press' step, a double-click action, or a
+        page-timeout target -- on ANY page, including this one. Used to
+        warn before deleting a page that's still pointed at."""
+        name = self._get_page_name(page_id)
+        refs = []
+        for from_page, acts in self._page_actions.items():
+            for i, act in enumerate(acts or []):
+                if not isinstance(act, dict):
+                    continue
+                if act.get("type") == "page" and act.get("target") == name:
+                    refs.append({"from_page": from_page, "key": i, "kind": "action"})
+                for step in (act.get("actions") or []):
+                    if step.get("type") == "page" and step.get("target") == name:
+                        refs.append({"from_page": from_page, "key": i, "kind": "also_on_press"})
+                dbl = act.get("double")
+                if isinstance(dbl, dict) and dbl.get("type") == "page" and dbl.get("target") == name:
+                    refs.append({"from_page": from_page, "key": i, "kind": "double_click"})
+        for from_page, to in (self._page_timeout or {}).items():
+            if isinstance(to, dict) and to.get("target") == name:
+                refs.append({"from_page": from_page, "key": None, "kind": "timeout"})
+        return refs
+
+    def _delete_page(self, page_id):
+        """Remove a page's data, its stored file, and switch away from it
+        first if it was the one currently on screen. Does NOT clean up
+        references to it elsewhere (#54) -- those buttons are left as-is
+        and will simply fail to resolve a target next time they're used;
+        the delete-page UI is expected to have already warned about that."""
+        page_id = int(page_id)
+        if page_id == 0:
+            return False
+        if not _delete_displaypad_page(page_id):
+            return False
+        self._page_actions.pop(page_id, None)
+        self._page_images.pop(page_id, None)
+        self._page_fullscreen.pop(page_id, None)
+        self._page_timeout.pop(page_id, None)
+        self._page_gif_frames.pop(page_id, None)
+        self._page_gui_frames.pop(page_id, None)
+        self._save_sub_pages()
+        _save_displaypad_page_timeouts(self._page_timeout)
+        if self._current_page == page_id:
+            self._switch_to_page(0)
+        return True
 
     def _get_extra_actions(self, idx):
         """Extra action steps for button idx (issue #17). Stored as an `actions`

--- a/lang/de.json
+++ b/lang/de.json
@@ -422,5 +422,17 @@
   "rgb_cmode_rainbow": "Regenbogen",
   "rgb_build_label": "BaseCamp Linux v{ver}",
   "dp_page_target": "Zu Seite:",
-  "dp_new_page": "＋ Neue Seite"
+  "dp_new_page": "＋ Neue Seite",
+  "dp_page_name_prompt": "Seitenname:",
+  "dp_page_name_title": "Neue Seite",
+  "dp_rename_page_title": "Seite umbenennen",
+  "dp_delete_page_title": "Seite löschen",
+  "dp_delete_page_main_error": "Die Hauptseite kann nicht gelöscht werden — die App startet nun mal darauf.",
+  "dp_delete_page_confirm": "\"{name}\" löschen? Dies kann nicht rückgängig gemacht werden.",
+  "dp_delete_page_referenced_warning": "\"{name}\" wird noch von {count} Taste(n)/Timeout(s) angesteuert. Beim Löschen zeigen diese ins Leere:",
+  "dp_delete_page_more": "…und {count} weitere",
+  "dp_ref_kind_action": "Seitenwechsel-Aktion",
+  "dp_ref_kind_also_on_press": "Auch beim Drücken",
+  "dp_ref_kind_double_click": "Doppelklick-Aktion",
+  "dp_ref_kind_timeout": "Auto-Timeout-Ziel"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -421,5 +421,17 @@
   "rgb_cmode_rainbow": "Rainbow",
   "rgb_build_label": "BaseCamp Linux v{ver}",
   "dp_page_target": "Go to page:",
-  "dp_new_page": "＋ New page"
+  "dp_new_page": "＋ New page",
+  "dp_page_name_prompt": "Page name:",
+  "dp_page_name_title": "New page",
+  "dp_rename_page_title": "Rename page",
+  "dp_delete_page_title": "Delete page",
+  "dp_delete_page_main_error": "The Main page can't be deleted — it's just the page the app opens on.",
+  "dp_delete_page_confirm": "Delete \"{name}\"? This can't be undone.",
+  "dp_delete_page_referenced_warning": "\"{name}\" is still targeted by {count} button(s)/timeout(s). Deleting it will leave those pointing at a page that no longer exists:",
+  "dp_delete_page_more": "…and {count} more",
+  "dp_ref_kind_action": "Switch page action",
+  "dp_ref_kind_also_on_press": "Also on press",
+  "dp_ref_kind_double_click": "Double-click action",
+  "dp_ref_kind_timeout": "Auto-timeout target"
 }

--- a/shared/config.py
+++ b/shared/config.py
@@ -842,11 +842,18 @@ def _clear_displaypad_fullscreen():
         pass
 
 
-def _load_displaypad_actions():
-    """Return list of 12 dicts with 'type' and 'action' keys."""
+def _load_displaypad_actions(page=0):
+    """Return list of 12 dicts with 'type' and 'action' keys for the given
+    DisplayPad page (0 = main page, matching self._current_page in the
+    DisplayPad panel). Sub-page actions are stored separately (see
+    _load_displaypad_pages) so plugins that only ever asked for the main
+    page's actions used to miss anything assigned on a sub-page."""
     default = [{"type": "none", "action": ""} for _ in range(12)]
     try:
-        data = _read_json(DISPLAYPAD_ACTIONS_FILE)
+        if page:
+            data = _load_displaypad_pages().get(str(page), {}).get("actions", [])
+        else:
+            data = _read_json(DISPLAYPAD_ACTIONS_FILE)
         for i in range(12):
             if i < len(data):
                 default[i].update(data[i])

--- a/shared/config.py
+++ b/shared/config.py
@@ -1,5 +1,6 @@
 """Shared configuration paths and load/save helpers for BaseCamp Linux."""
 import os
+import re
 import sys
 import json
 import pwd as _pwd
@@ -75,6 +76,8 @@ DISPLAYPAD_BTN_FILE        = os.path.join(CONFIG_DIR, "displaypad_buttons.json")
 DISPLAYPAD_FULLSCREEN_FILE = os.path.join(CONFIG_DIR, "displaypad_fullscreen.json")
 DISPLAYPAD_ACTIONS_FILE    = os.path.join(CONFIG_DIR, "displaypad_actions.json")
 DISPLAYPAD_PAGES_FILE      = os.path.join(CONFIG_DIR, "displaypad_pages.json")
+DISPLAYPAD_PAGE_NAMES_FILE = os.path.join(CONFIG_DIR, "displaypad_page_names.json")
+DISPLAYPAD_PAGES_DIR       = os.path.join(CONFIG_DIR, "displaypad_pages")
 DISPLAYPAD_TIMEOUTS_FILE   = os.path.join(CONFIG_DIR, "displaypad_page_timeouts.json")
 DISPLAYPAD_ROTATION_FILE    = os.path.join(CONFIG_DIR, "displaypad_rotation")
 DISPLAYPAD_BRIGHTNESS_FILE  = os.path.join(CONFIG_DIR, "displaypad_brightness")
@@ -810,105 +813,412 @@ def _save_makalu_remap(assignments):
 
 # ── DisplayPad config ────────────────────────────────────────────────────────
 
-def _load_displaypad_buttons():
-    """Return dict {str(key_idx): image_path} for DisplayPad button images."""
+# ── DisplayPad config ────────────────────────────────────────────────────────
+#
+# Every page (including page 0 / Main) lives in its own file under
+# DISPLAYPAD_PAGES_DIR, named after the page (#53) -- e.g.
+# "displaypad_pages/Monitoring__3.json". The numeric id is kept as a
+# filename suffix purely as a collision guard (two pages could otherwise be
+# renamed to the same thing); it is NOT used as the primary reference
+# anywhere in the app anymore -- actions, chain steps, and timeouts all
+# refer to a page by its name (see panel.py's _page_target()). The
+# functions below keep their historical signatures so callers don't need to
+# change; only the on-disk representation changed.
+
+_PAGE_FILENAME_UNSAFE = re.compile(r'[^A-Za-z0-9 _.\-]+')
+
+_EMPTY_ACTIONS = [{"type": "none", "action": ""} for _ in range(12)]
+
+
+def _page_dir():
+    os.makedirs(DISPLAYPAD_PAGES_DIR, exist_ok=True)
+    return DISPLAYPAD_PAGES_DIR
+
+
+def _page_filename(page_id, name):
+    safe = _PAGE_FILENAME_UNSAFE.sub("_", (name or "").strip()) or "page"
+    safe = safe.strip("_.") or "page"
+    return f"{safe}__{int(page_id)}.json"
+
+
+def _find_page_file(page_id):
+    """Locate an existing page's file by id -- its name (and therefore
+    filename) may have changed since it was last written, so this scans
+    rather than guessing the current filename."""
+    page_id = int(page_id)
+    suffix = f"__{page_id}.json"
     try:
-        return _read_json(DISPLAYPAD_BTN_FILE)
+        entries = os.listdir(_page_dir())
+    except OSError:
+        return None
+    for fn in entries:
+        if fn.endswith(suffix):
+            return os.path.join(_page_dir(), fn)
+    return None
+
+
+def _load_all_displaypad_pages():
+    """Return {page_id: {"id","name","v","actions","buttons","fullscreen",
+    "timeout"}} by reading every page's own file. Migrates the old combined
+    files into this layout the first time it's called on an existing
+    install (see _migrate_legacy_displaypad_pages)."""
+    _migrate_legacy_displaypad_pages()
+    out = {}
+    try:
+        entries = os.listdir(_page_dir())
+    except OSError:
+        entries = []
+    for fn in entries:
+        if not fn.endswith(".json"):
+            continue
+        try:
+            data = _read_json(os.path.join(_page_dir(), fn))
+        except Exception:
+            continue
+        if not isinstance(data, dict):
+            continue
+        try:
+            pid = int(data.get("id"))
+        except (TypeError, ValueError):
+            continue
+        out[pid] = data
+    return out
+
+
+def _save_displaypad_page_record(page_id, record):
+    """Write one page's complete record to its own file, renaming the file
+    if the page's name changed since it was last saved."""
+    page_id = int(page_id)
+    record = dict(record)
+    record["id"] = page_id
+    record.setdefault("name", "Main" if page_id == 0 else f"Page {page_id}")
+    old_path = _find_page_file(page_id)
+    new_path = os.path.join(_page_dir(), _page_filename(page_id, record["name"]))
+    if old_path and old_path != new_path and os.path.exists(old_path):
+        try:
+            os.remove(old_path)
+        except OSError:
+            pass
+    with open(new_path, "w") as f:
+        json.dump(record, f, indent=2)
+
+
+def _delete_displaypad_page_record(page_id):
+    path = _find_page_file(page_id)
+    if path and os.path.exists(path):
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+
+def _migrate_legacy_displaypad_pages():
+    """One-time upgrade (#53): fold the old separate files (displaypad_
+    actions.json, displaypad_buttons.json, displaypad_fullscreen.json,
+    displaypad_pages.json, displaypad_page_timeouts.json, displaypad_
+    page_names.json) into one file per page. Skipped once the per-page
+    directory has anything in it -- the old files are left on disk
+    untouched (unused, but nothing is deleted)."""
+    try:
+        if os.listdir(_page_dir()):
+            return
+    except OSError:
+        pass
+
+    names = {}
+    try:
+        raw = _read_json(DISPLAYPAD_PAGE_NAMES_FILE)
+        if isinstance(raw, dict):
+            for k, v in raw.items():
+                try:
+                    names[int(k)] = str(v)
+                except (TypeError, ValueError):
+                    pass
     except Exception:
-        return {}
+        pass
+
+    timeouts = {}
+    try:
+        raw = _read_json(DISPLAYPAD_TIMEOUTS_FILE)
+        if isinstance(raw, dict):
+            for k, v in raw.items():
+                try:
+                    timeouts[int(k)] = v
+                except (TypeError, ValueError):
+                    pass
+    except Exception:
+        pass
+
+    records = {}
+
+    try:
+        main_actions = _read_json(DISPLAYPAD_ACTIONS_FILE)
+    except Exception:
+        main_actions = list(_EMPTY_ACTIONS)
+    try:
+        main_buttons = _read_json(DISPLAYPAD_BTN_FILE)
+    except Exception:
+        main_buttons = {}
+    try:
+        main_fullscreen = _read_json(DISPLAYPAD_FULLSCREEN_FILE).get("gif_path")
+    except Exception:
+        main_fullscreen = None
+    records[0] = {
+        "id": 0, "name": names.get(0, "Main"), "v": 2,
+        "actions": main_actions, "buttons": main_buttons,
+        "fullscreen": main_fullscreen, "timeout": timeouts.get(0),
+    }
+
+    try:
+        raw_pages = _read_json(DISPLAYPAD_PAGES_FILE)
+    except Exception:
+        raw_pages = {}
+    if isinstance(raw_pages, dict):
+        for ps, pdata in raw_pages.items():
+            try:
+                pid = int(ps)
+            except (TypeError, ValueError):
+                continue
+            if not isinstance(pdata, dict):
+                continue
+            records[pid] = {
+                "id": pid, "name": names.get(pid, f"Page {pid}"),
+                "v": pdata.get("v", 1),
+                "actions": pdata.get("actions", list(_EMPTY_ACTIONS)),
+                "buttons": pdata.get("buttons", {}),
+                "fullscreen": pdata.get("fullscreen"),
+                "timeout": timeouts.get(pid),
+            }
+
+    # A page that only ever got a *name* registered (created ahead of time,
+    # #52) but never made it into the old combined-pages file.
+    for pid, nm in names.items():
+        if pid not in records:
+            records[pid] = {
+                "id": pid, "name": nm, "v": 2,
+                "actions": list(_EMPTY_ACTIONS), "buttons": {},
+                "fullscreen": None, "timeout": timeouts.get(pid),
+            }
+
+    for pid, record in records.items():
+        _save_displaypad_page_record(pid, record)
+
+
+def _load_displaypad_buttons():
+    """Return dict {str(key_idx): image_path} for Main's button images."""
+    rec = _load_all_displaypad_pages().get(0)
+    return (rec or {}).get("buttons") or {}
 
 
 def _save_displaypad_buttons(data):
-    with open(DISPLAYPAD_BTN_FILE, "w") as f:
-        f.write(json.dumps(data))
+    recs = _load_all_displaypad_pages()
+    rec = recs.get(0, {"id": 0, "name": "Main", "v": 2, "actions": list(_EMPTY_ACTIONS),
+                        "fullscreen": None, "timeout": None})
+    rec["buttons"] = data
+    _save_displaypad_page_record(0, rec)
 
 
 def _load_displaypad_fullscreen():
-    try:
-        return _read_json(DISPLAYPAD_FULLSCREEN_FILE).get("gif_path")
-    except Exception:
-        return None
+    rec = _load_all_displaypad_pages().get(0)
+    return (rec or {}).get("fullscreen")
 
 
 def _save_displaypad_fullscreen(path):
-    with open(DISPLAYPAD_FULLSCREEN_FILE, "w") as f:
-        f.write(json.dumps({"gif_path": path}))
+    recs = _load_all_displaypad_pages()
+    rec = recs.get(0, {"id": 0, "name": "Main", "v": 2, "actions": list(_EMPTY_ACTIONS),
+                        "buttons": {}, "timeout": None})
+    rec["fullscreen"] = path
+    _save_displaypad_page_record(0, rec)
 
 
 def _clear_displaypad_fullscreen():
-    try:
-        os.remove(DISPLAYPAD_FULLSCREEN_FILE)
-    except Exception:
-        pass
+    _save_displaypad_fullscreen(None)
 
 
-def _load_displaypad_actions():
-    """Return list of 12 dicts with 'type' and 'action' keys."""
+def _load_displaypad_actions(page=0):
+    """Return list of 12 dicts with 'type' and 'action' keys for the given
+    DisplayPad page (0 = main page, matching self._current_page in the
+    DisplayPad panel)."""
     default = [{"type": "none", "action": ""} for _ in range(12)]
-    try:
-        data = _read_json(DISPLAYPAD_ACTIONS_FILE)
-        for i in range(12):
-            if i < len(data):
-                default[i].update(data[i])
-    except Exception:
-        pass
+    rec = _load_all_displaypad_pages().get(page)
+    data = (rec or {}).get("actions") or []
+    for i in range(12):
+        if i < len(data):
+            default[i].update(data[i])
     return default
 
 
 def _save_displaypad_actions(actions):
-    with open(DISPLAYPAD_ACTIONS_FILE, "w") as f:
-        json.dump(actions, f, indent=2)
+    """Save Main's (page 0's) actions."""
+    recs = _load_all_displaypad_pages()
+    rec = recs.get(0, {"id": 0, "name": "Main", "v": 2, "buttons": {},
+                        "fullscreen": None, "timeout": None})
+    rec["actions"] = actions
+    _save_displaypad_page_record(0, rec)
 
 
 def _load_displaypad_pages():
-    """Return dict {str(page_num): {buttons: {}, actions: [...], fullscreen: None}}."""
-    try:
-        return _read_json(DISPLAYPAD_PAGES_FILE)
-    except Exception:
-        return {}
+    """Return {str(page_id): {"v","buttons","actions","fullscreen"}} for
+    every page EXCEPT page 0/Main (which has its own _load/_save_displaypad_
+    actions/buttons/fullscreen functions) -- matches the historical
+    contract used by panel.py's page-loading and _save_sub_pages()."""
+    out = {}
+    for pid, rec in _load_all_displaypad_pages().items():
+        if pid == 0:
+            continue
+        out[str(pid)] = {
+            "v": rec.get("v", 2),
+            "buttons": rec.get("buttons", {}),
+            "actions": rec.get("actions", list(_EMPTY_ACTIONS)),
+            "fullscreen": rec.get("fullscreen"),
+        }
+    return out
 
 
 def _save_displaypad_pages(data):
-    with open(DISPLAYPAD_PAGES_FILE, "w") as f:
-        json.dump(data, f, indent=2)
+    """data: {str(page_id): {"v","buttons","actions","fullscreen"}} for
+    every non-main page (the exact shape panel.py's _save_sub_pages()
+    builds). Each page is written to its own file; a page that was on disk
+    before but is missing from `data` now (e.g. deleted) has its file
+    removed too -- the same "whole state overwrite" semantics the old
+    single combined-file format had."""
+    recs = _load_all_displaypad_pages()
+    seen = set()
+    for ps, pdata in (data or {}).items():
+        try:
+            pid = int(ps)
+        except (TypeError, ValueError):
+            continue
+        if pid == 0:
+            continue
+        seen.add(pid)
+        rec = recs.get(pid, {})
+        rec.update({
+            "id": pid,
+            "name": rec.get("name") or f"Page {pid}",
+            "v": pdata.get("v", 2),
+            "buttons": pdata.get("buttons", {}),
+            "actions": pdata.get("actions", list(_EMPTY_ACTIONS)),
+            "fullscreen": pdata.get("fullscreen"),
+            "timeout": rec.get("timeout"),
+        })
+        _save_displaypad_page_record(pid, rec)
+    for pid in list(recs.keys()):
+        if pid != 0 and pid not in seen:
+            _delete_displaypad_page_record(pid)
 
+
+def _load_displaypad_page_names():
+    """Return {int page_id: str name} for every page that exists. This is
+    the authoritative registry of which pages *exist* -- independent of
+    whether any button currently targets them, so a page can be created
+    ahead of time and won't vanish for being "unused". Page 0 (the page the
+    app happens to open on) is just another entry here; if it has no
+    stored name yet, the caller is responsible for filling in a translated
+    default (kept out of this low-level function since it doesn't have
+    access to translations)."""
+    return {pid: rec.get("name", f"Page {pid}")
+            for pid, rec in _load_all_displaypad_pages().items()}
+
+
+def _save_displaypad_page_names(names):
+    """names: {int page_id: str name}. Kept for callers that batch-update
+    the whole name map at once; updates just the 'name' field (and
+    therefore filename) of each affected page's own file."""
+    recs = _load_all_displaypad_pages()
+    for pid, name in (names or {}).items():
+        pid = int(pid)
+        rec = recs.get(pid, {"id": pid, "v": 2, "actions": list(_EMPTY_ACTIONS),
+                              "buttons": {}, "fullscreen": None, "timeout": None})
+        rec["name"] = name
+        _save_displaypad_page_record(pid, rec)
+
+
+def _create_displaypad_page(name, existing_ids=None):
+    """Register a brand-new, currently-unused page with the given name and
+    return its id. `existing_ids` lets a caller fold in ids it already
+    knows about from elsewhere (legacy configs where a page id was only
+    ever implied by a button's stored target) so the new id can't collide
+    with those either."""
+    known = set(_load_all_displaypad_pages().keys()) | {0}
+    if existing_ids:
+        known.update(int(i) for i in existing_ids)
+    new_id = max(known) + 1
+    record = {
+        "id": new_id, "name": name, "v": 2,
+        "actions": list(_EMPTY_ACTIONS), "buttons": {},
+        "fullscreen": None, "timeout": None,
+    }
+    _save_displaypad_page_record(new_id, record)
+    return new_id
+
+
+def _rename_displaypad_page(page_id, name):
+    page_id = int(page_id)
+    rec = _load_all_displaypad_pages().get(
+        page_id, {"id": page_id, "v": 2, "actions": list(_EMPTY_ACTIONS),
+                  "buttons": {}, "fullscreen": None, "timeout": None})
+    rec["name"] = name
+    _save_displaypad_page_record(page_id, rec)
+
+
+def _delete_displaypad_page(page_id):
+    """Remove a page entirely. Page 0 can't be deleted -- it always
+    exists, it's just the page the app happens to open on."""
+    page_id = int(page_id)
+    if page_id == 0:
+        return False
+    if page_id not in _load_all_displaypad_pages():
+        return False
+    _delete_displaypad_page_record(page_id)
+    return True
 
 
 def _load_displaypad_page_timeouts():
     """Per-page auto-timeout config (issue #45).
 
     Returns {int(page): {"mode": "off"|"after"|"idle", "seconds": int,
-    "target": int|"prev"}}. 'after' fires N seconds after the page is shown;
-    'idle' fires N seconds after the last keypress on that page."""
+    "target": str|"prev"}}. 'after' fires N seconds after the page is
+    shown; 'idle' fires N seconds after the last keypress on that page.
+    'target' is a page NAME (#52), resolved against the page registry by
+    the caller -- it is deliberately NOT int()-coerced here, since a named
+    target is a string on purpose, not a legacy numeric id."""
     out = {}
-    try:
-        raw = _read_json(DISPLAYPAD_TIMEOUTS_FILE)
-        for k, v in (raw or {}).items():
-            if not isinstance(v, dict):
-                continue
-            tgt = v.get("target", 0)
-            if tgt != "prev":
-                try:
-                    tgt = int(tgt)
-                except (TypeError, ValueError):
-                    tgt = 0
-            out[int(k)] = {
-                "mode": v.get("mode", "off"),
-                "seconds": int(v.get("seconds", 0) or 0),
-                "target": tgt,
-            }
-    except Exception:
-        pass
+    for pid, rec in _load_all_displaypad_pages().items():
+        v = rec.get("timeout")
+        if not isinstance(v, dict) or v.get("mode", "off") == "off":
+            continue
+        tgt = v.get("target", 0)
+        if tgt != "prev" and not isinstance(tgt, str):
+            try:
+                tgt = int(tgt)
+            except (TypeError, ValueError):
+                tgt = 0
+        out[pid] = {
+            "mode": v.get("mode", "off"),
+            "seconds": int(v.get("seconds", 0) or 0),
+            "target": tgt,
+        }
     return out
 
 
 def _save_displaypad_page_timeouts(data):
-    out = {}
-    for p, v in (data or {}).items():
+    """data: {page_id: {"mode","seconds","target"} or None to clear}."""
+    recs = _load_all_displaypad_pages()
+    all_ids = set(recs.keys()) | {int(k) for k in (data or {}).keys()}
+    for pid in all_ids:
+        v = (data or {}).get(pid, (data or {}).get(str(pid)))
+        to = None
         if isinstance(v, dict) and v.get("mode", "off") != "off" and int(v.get("seconds", 0) or 0) > 0:
-            out[str(p)] = v
-    with open(DISPLAYPAD_TIMEOUTS_FILE, "w") as f:
-        json.dump(out, f, indent=2)
+            to = v
+        rec = recs.get(pid)
+        if rec is None:
+            if to is None:
+                continue  # nothing to persist, and the page doesn't exist yet
+            rec = {"id": pid, "v": 2, "actions": list(_EMPTY_ACTIONS),
+                   "buttons": {}, "fullscreen": None}
+        rec["timeout"] = to
+        _save_displaypad_page_record(pid, rec)
 
 
 def _load_displaypad_rotation():

--- a/shared/plugin_api.py
+++ b/shared/plugin_api.py
@@ -93,6 +93,25 @@ class PluginContext:
         if dp and hasattr(dp, "push_plugin_image"):
             dp.push_plugin_image(key_index, pil_image)
 
+    def get_displaypad_current_page(self):
+        """Return the DisplayPad's currently active page number (0 = main
+        page), or 0 if the DisplayPad isn't connected. Use this instead of
+        assuming page 0 so widgets/actions assigned on a sub-page are found.
+        """
+        dp = self.get_displaypad()
+        return getattr(dp, "_current_page", 0) if dp else 0
+
+    def get_displaypad_actions(self, page=None):
+        """Return the 12 button actions for a DisplayPad page. Defaults to
+        whichever page is currently on screen, so a plugin's "which button
+        am I assigned to" lookup works on sub-pages too, not just the main
+        page.
+        """
+        from shared.config import _load_displaypad_actions
+        if page is None:
+            page = self.get_displaypad_current_page()
+        return _load_displaypad_actions(page)
+
     # ── Action registration ───────────────────────────────────────────────────
 
     def register_action_type(self, type_id, label, handler, value_options=None):
@@ -110,5 +129,6 @@ class PluginContext:
         self._pm._action_types[type_id] = {
             "label": label,
             "handler": handler,
+            "owner": getattr(self._pm, "_loading_pid", None),
             "value_options": value_options,
         }

--- a/shared/plugins.py
+++ b/shared/plugins.py
@@ -6,6 +6,16 @@ import importlib.util
 
 from shared.config import CONFIG_DIR, PLUGINS_DISABLED_FILE
 
+# Set BASECAMP_PAGE_DEBUG=1 in the environment to trace page-scoped
+# start/stop decisions (also toggles matching trace lines in
+# devices/displaypad/panel.py and page-bound widget plugins). Off by default.
+_DEBUG = os.environ.get("BASECAMP_PAGE_DEBUG", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _dbg(msg):
+    if _DEBUG:
+        print(msg, flush=True)
+
 PLUGINS_DIR = os.path.join(CONFIG_DIR, "plugins")
 
 
@@ -18,6 +28,9 @@ class PluginManager:
         self._action_types = {}  # type_id -> {"label", "handler"}
         self._disabled = set()   # set of disabled plugin IDs
         self._errors = {}        # id -> error string
+        self._running = {}       # id -> bool, service plugins currently start()-ed
+        self._loading_pid = None  # set while instantiating a plugin, so
+                                   # register_action_type() can tag ownership
         self._load_disabled()
 
     def _load_disabled(self):
@@ -76,8 +89,12 @@ class PluginManager:
             spec = importlib.util.spec_from_file_location(f"plugins.{pid}", mod_path)
             mod = importlib.util.module_from_spec(spec)
             sys.modules[f"plugins.{pid}"] = mod
-            spec.loader.exec_module(mod)
-            instance = mod.Plugin(context)
+            self._loading_pid = pid  # so ctx.register_action_type can tag ownership
+            try:
+                spec.loader.exec_module(mod)
+                instance = mod.Plugin(context)
+            finally:
+                self._loading_pid = None
             self._instances[pid] = instance
             self._errors.pop(pid, None)
             print(f"[Plugin] Loaded: {info.get('name', pid)} v{info.get('version', '?')}")
@@ -118,6 +135,7 @@ class PluginManager:
                     inst.stop()
                 except Exception:
                     pass
+            self._running.pop(pid, None)
             # Remove any action types this plugin registered
             to_remove = [tid for tid, d in self._action_types.items()
                          if getattr(d.get("handler"), "__self__", None) is inst]
@@ -137,6 +155,7 @@ class PluginManager:
                     inst.stop()
                 except Exception:
                     pass
+            self._running.pop(pid, None)
             # Remove action types registered by old instance
             to_remove = [tid for tid, d in self._action_types.items()
                          if getattr(d.get("handler"), "__self__", None) is inst]
@@ -153,18 +172,26 @@ class PluginManager:
         # Re-load
         if not self._load_one(pid, info, self._context):
             return False
-        # Re-start service if applicable
+        # Re-start service if applicable (only if not bound to a button on a
+        # page that isn't currently showing)
         new_inst = self._instances.get(pid)
         if new_inst:
             ptypes = info.get("type", "")
             if isinstance(ptypes, str):
                 ptypes = [ptypes]
-            if "service" in ptypes and hasattr(new_inst, "start"):
-                try:
-                    new_inst.start()
-                except Exception as e:
-                    print(f"[Plugin] Failed to start {pid}: {e}")
+            if "service" in ptypes:
+                if self._owns_a_button(pid) and pid not in self._bound_plugins_for_page(self._current_page()):
+                    pass  # its button is on a different page -- stays off until shown
+                else:
+                    self._start_pid(pid, new_inst, info)
         return True
+
+    def _current_page(self):
+        """Best-effort lookup of the DisplayPad's active page via the stored
+        plugin context (defaults to 0 if unavailable)."""
+        ctx = getattr(self, "_context", None)
+        get_page = getattr(ctx, "get_displaypad_current_page", None)
+        return get_page() if callable(get_page) else 0
 
     def enable_plugin(self, pid):
         """Enable a plugin. Loads it immediately if possible."""
@@ -179,11 +206,11 @@ class PluginManager:
                     ptypes = info.get("type", "")
                     if isinstance(ptypes, str):
                         ptypes = [ptypes]
-                    if "service" in ptypes and hasattr(inst, "start"):
-                        try:
-                            inst.start()
-                        except Exception as e:
-                            print(f"[Plugin] Failed to start {pid}: {e}")
+                    if "service" in ptypes:
+                        if self._owns_a_button(pid) and pid not in self._bound_plugins_for_page(self._current_page()):
+                            pass
+                        else:
+                            self._start_pid(pid, inst, info)
 
     # ── Panel plugins ─────────────────────────────────────────────────────────
 
@@ -239,21 +266,95 @@ class PluginManager:
                 result.append((s, s))
         return result
 
+    # ── DisplayPad page-scoped services ───────────────────────────────────────
+    #
+    # A service plugin that also registers an action type (e.g. Now Playing,
+    # via register_action_type) is "page-bound": it only makes sense to run
+    # while a button on the currently visible DisplayPad page has that action
+    # type assigned. Such plugins are started/stopped with their normal
+    # start()/stop() lifecycle as the user switches pages — no extra hook is
+    # required in the plugin interface. A service plugin that registers no
+    # action type at all (e.g. a background socket server) is treated as
+    # global and simply runs for the whole app lifetime, as before.
+
+    def _owns_a_button(self, pid):
+        """True if this plugin registered at least one action type."""
+        return any(d.get("owner") == pid for d in self._action_types.values())
+
+    def _bound_plugins_for_page(self, page):
+        """Return the set of plugin ids whose registered action type is
+        assigned to some button on the given DisplayPad page."""
+        from shared.config import _load_displaypad_actions
+        actions = _load_displaypad_actions(page)
+        assigned = {a.get("type") for a in actions if a.get("type") not in (None, "none")}
+        bound = set()
+        for tid in assigned:
+            entry = self._action_types.get(tid)
+            if entry and entry.get("owner"):
+                bound.add(entry["owner"])
+        return bound
+
+    def _start_pid(self, pid, inst, info, reason=""):
+        if not hasattr(inst, "start"):
+            return
+        try:
+            inst.start()
+            self._running[pid] = True
+            print(f"[Plugin] Started service{reason}: {info.get('name', pid)}")
+        except Exception as e:
+            print(f"[Plugin] Failed to start {pid}: {e}")
+
+    def _stop_pid(self, pid, inst, info, reason=""):
+        if not hasattr(inst, "stop"):
+            return
+        try:
+            inst.stop()
+        except Exception:
+            pass
+        self._running[pid] = False
+        print(f"[Plugin] Stopped service{reason}: {info.get('name', pid)}")
+
+    def sync_services_for_page(self, page):
+        """Call this whenever the DisplayPad's active page changes. Stops
+        page-bound service plugins whose button isn't on the new page and
+        starts the ones whose button is — using their own start()/stop()."""
+        bound = self._bound_plugins_for_page(page)
+        _dbg(f"[DBG PluginManager] sync_services_for_page({page}): bound={bound} "
+             f"running={dict(self._running)}")
+        for pid, inst in list(self._instances.items()):
+            info = self._manifests.get(pid, {})
+            ptypes = info.get("type", "")
+            if isinstance(ptypes, str):
+                ptypes = [ptypes]
+            if "service" not in ptypes or not self._owns_a_button(pid):
+                continue  # not a service, or a global service -- leave alone
+            should_run = pid in bound
+            is_running = self._running.get(pid, False)
+            _dbg(f"[DBG PluginManager]   {pid}: should_run={should_run} is_running={is_running}")
+            if should_run and not is_running:
+                self._start_pid(pid, inst, info, f" (page {page})")
+            elif not should_run and is_running:
+                self._stop_pid(pid, inst, info, f" (button not on page {page})")
+
+
     # ── Service lifecycle ─────────────────────────────────────────────────────
 
     def start_services(self):
-        """Call start() on all service-type plugins."""
+        """Call start() on all service-type plugins. A plugin that binds to a
+        specific DisplayPad button only starts if that button is on the
+        page shown at launch (page 0); it will start later via
+        sync_services_for_page() once its page becomes active. A plugin with
+        no button binding is global and always starts with the app."""
         for pid, inst in self._instances.items():
             info = self._manifests[pid]
             ptypes = info.get("type", "")
             if isinstance(ptypes, str):
                 ptypes = [ptypes]
-            if "service" in ptypes and hasattr(inst, "start"):
-                try:
-                    inst.start()
-                    print(f"[Plugin] Started service: {info.get('name', pid)}")
-                except Exception as e:
-                    print(f"[Plugin] Failed to start {pid}: {e}")
+            if "service" not in ptypes:
+                continue
+            if self._owns_a_button(pid) and pid not in self._bound_plugins_for_page(0):
+                continue
+            self._start_pid(pid, inst, info)
 
     def shutdown(self):
         """Call stop() on all plugins that have it."""
@@ -263,3 +364,4 @@ class PluginManager:
                     inst.stop()
                 except Exception:
                     pass
+                self._running[pid] = False


### PR DESCRIPTION
NOTE: PROBABLY BEST MERGE THIS AFTER MY OTHER PR'S TO AVOID POTENTIAL CONFLICTS

    displaypad: name panels and give them their own json
    
    Since panels are not related any more to specific keys the numbering
    made a bit less sense.
    This patch introduces the following changes
    - use the name as the primary target
    - give each page it's own json file
    - treat Main as any other page. The only difference is that it is
      the page that is shown initially
    - allow creation of pages before they are referenced
    
    Pages are migrated from the old displaypad_pages.json and
    displaypad_actions.json and displaypad_buttons.json
    and are moved to a displaypad_pages folder
    
    Internally pages are still referred to with a number.
    Changing this would break the plugin api.
    
    Selecting the "+ New page" will prompt for the new page.
    
    Still open: deleting of pages

