### PR TITLE
everest_max: re-claim the keyboard after a USB port reset

### DIFF
--- a/emax_controller.py
+++ b/emax_controller.py
@@ -80,6 +80,34 @@ def _get_claimed_device():
             time.sleep(0.5)
     print("Failed to claim interface", file=sys.stderr); sys.exit(1)
 
+
+def _reclaim(dev):
+    """Claim the keyboard again after a USB port reset.
+
+    Suspend/resume resets the port and re-enumerates the board, which leaves
+    the claimed interface dead: every write fails from then on.
+    """
+    try:
+        _release(dev)
+    except Exception:
+        pass
+    for _ in range(20):
+        try:
+            if usb.core.find(idVendor=VID, idProduct=PID) is not None:
+                break
+        except usb.core.USBError:
+            pass  # still settling
+        time.sleep(0.5)
+    dev = _get_claimed_device()  # exits if the keyboard really went away
+    try:
+        dev.write(EP_OUT, make_packet(0x11, 0x12)); _read(dev)
+        dev.write(EP_OUT, make_packet(0x11, 0x14)); _read(dev)
+        print("USB reclaimed after device reset", file=sys.stderr, flush=True)
+    except usb.core.USBError as e:
+        # Board back but not awake yet: keep the handle, the loop retries.
+        print(f"re-init after reclaim failed: {e}", file=sys.stderr, flush=True)
+    return dev
+
 _EMPTY_PKT = bytes(PKT_SIZE)
 
 def _read(dev, timeout=1000):
@@ -893,6 +921,9 @@ def controller_loop(style=STYLE_ANALOG):
         _slow_last = 0  # tracks last update time for RAM/HDD
         # Smoothed metric values (EMA, alpha=0.2)
         _smooth = {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0}
+        _usb_fail = 0
+        # BOOTTIME counts time spent suspended, MONOTONIC does not.
+        _asleep = time.clock_gettime(time.CLOCK_BOOTTIME) - time.monotonic()
 
         def _run_action(btype, action):
             """Execute one button action by type. Issue #17 lets several run in
@@ -1024,6 +1055,13 @@ def controller_loop(style=STYLE_ANALOG):
         while True:
             now = time.monotonic()
 
+            # A jump means the machine was suspended, which reset the port.
+            _asleep_now = time.clock_gettime(time.CLOCK_BOOTTIME) - now
+            if _asleep_now - _asleep > 5:
+                dev = _reclaim(dev)
+                last_time_sync = 0  # the clock stood still while asleep
+            _asleep = _asleep_now
+
             # Re-read button config every 2 seconds
             if now - last_config_check >= 2.0:
                 buttons = read_buttons()
@@ -1102,18 +1140,31 @@ def controller_loop(style=STYLE_ANALOG):
                     dev.write(EP_OUT, make_packet(0x11, VOLUME_CMD, 0x00, 0x00,
                                                   vol))
                     _handle_btn_resp(_read(dev, timeout=150))
-            except usb.core.USBError:
-                pass  # Transient USB error — skip this cycle
 
-            # Time sync once per minute
-            if now - last_time_sync >= 60:
-                _send_time_packet(dev, style)
-                last_time_sync = now
+                # Time sync once per minute, in here so a USBError from it
+                # cannot escape and end the loop.
+                if now - last_time_sync >= 60:
+                    _send_time_packet(dev, style)
+                    last_time_sync = now
+                _usb_fail = 0
+            except usb.core.USBError as e:
+                # One bad cycle is transient; every cycle failing means the
+                # handle is dead and wants re-claiming.
+                _usb_fail += 1
+                if _usb_fail == 1:
+                    print(f"USB write failed: {e}", file=sys.stderr, flush=True)
+                if _usb_fail >= 10:
+                    dev = _reclaim(dev)
+                    _usb_fail = 0
+
             time.sleep(CPU_INTERVAL)
     except KeyboardInterrupt:
         pass  # Normal termination via SIGINT
     finally:
-        _release(dev)
+        try:
+            _release(dev)
+        except Exception:
+            pass
 
 # ── CLI ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
**Symptom.** After a suspend/resume the Monitor Mode panel still says *"Sending monitor data…"*, but the wheel display is frozen on a stale reading — here 98, which matched none of the five live metrics on screen. The display holds whatever the host last pushed for the metric the wheel has selected, so the number is from before the handle died, not something the firmware produced. Stop → Start monitor mode fixes it.

**Cause.** Resume resets the keyboard's USB port — `usb 1-5.2.1.1.2: reset full-speed USB device number 13 using xhci_hcd` — and re-enumerates it, so the interface `controller_loop()` claimed is dead. Every `dev.write()` then raises `usb.core.USBError`, which the loop swallowed with a bare `pass` and kept spinning forever. The GUI only checks `self._cpu_proc.poll()`, so a live-but-useless process reads as healthy.

**Fix.** `_reclaim(dev)`: release the dead handle, wait for the device to reappear, claim and re-init it. Called on either trigger:

- `CLOCK_BOOTTIME` pulling >5 s ahead of `CLOCK_MONOTONIC` — BOOTTIME counts time spent suspended and MONOTONIC does not, so the gap between them *is* the sleep;
- 10 consecutive failed cycles (~2 s), which also covers a replug or a hub glitch.

Everything that can raise lives inside `_reclaim`, so a board that comes back slowly logs and retries on the next cycle instead of killing the monitor. `_send_time_packet` moved inside the existing `try` for the same reason — a `USBError` from it used to escape and end the loop. The first error of each burst is printed to stderr, so `controller_error.log` has something in it next time instead of nothing.

**Reproducing it without a suspend.** With a monitor running, reset the port the way resume does:

```bash
N=$(lsusb -d 3282:0001 | sed -E 's|Bus ([0-9]+) Device ([0-9]+).*|/dev/bus/usb/\1/\2|')
python3 -c "import fcntl,os;fcntl.ioctl(os.open('$N',os.O_WRONLY),0x5514,0)"   # USBDEVFS_RESET
```

Before this change the display freezes until Stop/Start. After it, `~/.config/mountain-time-sync/controller_error.log` reads

```
USB write failed: [Errno 5] Input/Output Error
USB reclaimed after device reset
```

and the same process — not a restarted one — keeps updating the display.

**Testing.** Verified on 3.1.3 with the forced `USBDEVFS_RESET` above, plus three real suspend/resume cycles, all of which recovered and logged `USB reclaimed after device reset`. Worth noting which trigger actually fires: in every real resume so far the error burst hit first (a `USB write failed:` line precedes the reclaim), because the loop notices the dead handle within ~2 s of waking. The BOOTTIME check is the belt to that braces — it catches the case where the board comes back but writes keep succeeding into nothing.

Single file, no new dependencies, no behaviour change while the device is healthy.
