### PR TITLE
everest_max: clamp metric values to one byte

### DIFF
--- a/emax_controller.py
+++ b/emax_controller.py
@@ -1087,7 +1087,9 @@ def controller_loop(style=STYLE_ANALOG):
 
                 # Send all metrics (keyboard shows whichever the wheel selects)
                 for metric_type in range(5):
-                    value = min(int(_smooth[metric_type]), 999)
+                    # One packet byte, so 0-255. Network MB/s is the only
+                    # metric that is not a percentage and can leave that range.
+                    value = max(0, min(int(_smooth[metric_type]), 255))
                     dev.write(EP_OUT, make_packet(0x11, 0x81, metric_type, 0x00, value))
                     _handle_btn_resp(_read(dev, timeout=150))
 


### PR DESCRIPTION
**Symptom.** Monitor mode dies on its own, mid-session, with no user action. The wheel display freezes and the panel keeps claiming it is sending data, because the GUI only checks `self._cpu_proc.poll()` on a 5 s timer and the process is genuinely gone by then. `~/.config/mountain-time-sync/controller_error.log`:

```
Traceback (most recent call last):
  File "emax_entry.py", line 15, in <module>
  File "emax_controller.py", line 1257, in main
    controller_loop(style)
  File "emax_controller.py", line 1129, in controller_loop
    dev.write(EP_OUT, make_packet(0x11, 0x81, metric_type, 0x00, value))
  File "emax_controller.py", line 52, in make_packet
    pkt[i] = v
ValueError: byte must be in range(0, 256)
[PYI-1136867:ERROR] Failed to execute script 'emax_entry' due to unhandled exception!
```

**Cause.** `make_packet()` writes each argument into a `bytearray`, so every metric value has to fit one byte, but the send loop caps at 999:

```python
value = min(int(_smooth[metric_type]), 999)
```

Four of the five metrics are percentages and can never trip this. Slot 3 is network throughput in **MB/s**, which is not bounded by 100 — a 2.5GbE link peaks around 312 MB/s. Any sustained transfer above 255 MB/s therefore takes monitor mode down. Gigabit tops out at ~125 MB/s, which is presumably why this has gone unnoticed.

**Fix.** Clamp to the range the packet actually accepts:

```python
value = max(0, min(int(_smooth[metric_type]), 255))
```

The lower bound is not theoretical either: `net_bytes` is a delta of `psutil.net_io_counters()`, and when the interface counters reset (an `ifdown`/`ifup`, or a NIC that re-enumerates on resume) the delta comes out negative and feeds a negative value into the EMA.

Behaviour change is limited to the case that used to crash: network readings above 255 MB/s now pin at 255 instead of killing the process.

**Reproducing it.** Start monitor mode and push more than 255 MB/s across the interface for a few seconds — a large file copy from a NAS on 2.5GbE does it. Without the patch the controller exits with the traceback above; with it the display keeps updating and reads 255 while the transfer runs.

Independent of #101 — different failure, different line, applies cleanly on its own.
